### PR TITLE
Don't add /bin/sh as a dependency

### DIFF
--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -463,8 +463,6 @@ impl RPMBuilder {
             ino_index += 1;
         }
 
-        self.requires.push(Dependency::any("/bin/sh".to_string()));
-
         self.provides
             .push(Dependency::eq(self.name.clone(), self.version.clone()));
         self.provides.push(Dependency::eq(


### PR DESCRIPTION
This updates rpm-rs to not universally add /bin/sh as a required dependency.

I want to use rpm-rs (via cargo-generate-rpms) to create RPMs that don't depend on /bin/sh , as I want to then install the RPMs I'm producing into a container, and I don't want a shell and its dependencies installed in the container.

I can't find any rationale for the existing behaviour - it was added in https://github.com/rpm-rs/rpm-rs/commit/ecbcdabea59af48b5f9a6a915c2242a7d8a6d0c5#diff-43fb48f0415ccc8ae772c068cc4bc8717f04a0e93a4113396ce0b48deddd9af6.