### PR TITLE
Fix up remaining warnings in no-default-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      # Do a clippy check with warnings turned into errors.
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features -- -D warnings
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub use crate::errors::*;
 pub(crate) mod constants;
 pub use crate::constants::*;
 
+#[cfg(feature = "signature-meta")]
 mod sequential_cursor;
 
 mod rpm;

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -294,15 +294,14 @@ impl RPMBuilder {
 
         let mut header = Vec::with_capacity(128);
         header_idx_tag.write(&mut header)?;
-        let header = header;
-
-        let (header_digest_sha1, header_and_content_digest_md5) =
-            Self::derive_hashes(header.as_slice(), content.as_slice())?;
-
-        let header_and_content_len = header.len() + content.len();
 
         #[cfg(feature = "signature-meta")]
         let digest_header = {
+            let header = header;
+            let (header_digest_sha1, header_and_content_digest_md5) =
+                Self::derive_hashes(header.as_slice(), content.as_slice())?;
+            let header_and_content_len = header.len() + content.len();
+
             Header::<IndexSignatureTag>::builder()
                 .add_digest(
                     header_digest_sha1.as_str(),
@@ -370,6 +369,7 @@ impl RPMBuilder {
     }
 
     /// use prepared data but make sure the signatures are
+    #[cfg(feature = "signature-meta")]
     fn derive_hashes(header: &[u8], content: &[u8]) -> Result<(String, Vec<u8>), RPMError> {
         let digest_md5 = {
             use md5::Digest;

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -166,6 +166,7 @@ where
             .ok_or_else(|| RPMError::TagNotFound(tag.to_string()))
     }
 
+    #[cfg(feature = "signature-meta")]
     pub(crate) fn get_entry_binary_data(&self, tag: T) -> Result<&[u8], RPMError> {
         let entry = self.find_entry_or_err(&tag)?;
         entry
@@ -1135,6 +1136,7 @@ impl IndexData {
         }
     }
 
+    #[cfg(feature = "signature-meta")]
     pub(crate) fn as_binary(&self) -> Option<&[u8]> {
         match self {
             IndexData::Bin(d) => Some(d.as_slice()),

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -14,7 +14,6 @@ use crate::sequential_cursor::SeqCursor;
 #[cfg(feature = "signature-meta")]
 use crate::signature;
 
-use std::io::Read;
 #[cfg(feature = "signature-meta")]
 use std::io::{Seek, SeekFrom};
 
@@ -85,6 +84,7 @@ impl RPMPackage {
             use md5::Digest;
             let mut hasher = md5::Md5::default();
             {
+                use std::io::Read;
                 // avoid loading it into memory all at once
                 // since the content could be multiple 100s of MBs
                 let mut buf = [0u8; 256];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -325,6 +325,7 @@ fn test_rpm_header() -> Result<(), Box<dyn std::error::Error>> {
     test_rpm_header_base(package)
 }
 
+#[cfg(feature = "signature-meta")]
 #[test]
 fn test_region_tag() -> Result<(), Box<dyn std::error::Error>> {
     let region_entry = Header::create_region_tag(IndexSignatureTag::HEADER_SIGNATURES, 2, 400);


### PR DESCRIPTION
After #34 there were a few warnings. This fixes up the remainder.

The annotations are only required for the pub(crate) functions. I've manually tested with each feature enabled that this compiles, though at some point we should consider a matrix.