### PR TITLE
Switch `tokio` AsyncRead/Write traits to `futures` AsyncRead/Write traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.59.0"
 name = "rpm"
 
 [dependencies]
-tokio = {version = "1.11", optional = true}
+tokio = {version = "1.11", optional = true }
 thiserror = "1"
 nom = "7"
 num-traits = "0.2"
@@ -43,6 +43,7 @@ hex = { version = "0.4", features = ["std"] }
 zstd = "0.12.0"
 # Workaround for https://github.com/gyscos/zstd-rs/issues/177
 zstd-sys = "=2.0.1+zstd.1.5.2"
+futures = { version = "0.3.25", optional = true }
 
 [dev-dependencies]
 rsa = { version = "0.7" }
@@ -50,13 +51,15 @@ rsa-der = { version = "^0.3.0" }
 env_logger = "0.9.0"
 serial_test = "0.9"
 tokio = {version = "1", features = ["full"]}
+tokio-util = { version = "0.7.4", features = ["compat"] }
 reqwest = { version = "0.11.10", features = ["blocking"] }
 
 
 [features]
-default = ["signature-pgp","async-tokio"]
+default = ["signature-pgp", "async-futures", "async-tokio"]
 
 signature-pgp = ["signature-meta", "pgp"]
 signature-meta = []
 test-with-podman = ["signature-meta"]
-async-tokio = ["tokio/fs", "tokio/io-util"]
+async-tokio = ["tokio/fs"]
+async-futures = ["futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ rust-version = "1.59.0"
 name = "rpm"
 
 [dependencies]
-tokio = {version = "1.11", optional = true }
 thiserror = "1"
 nom = "7"
 num-traits = "0.2"
@@ -44,6 +43,7 @@ zstd = "0.12.0"
 # Workaround for https://github.com/gyscos/zstd-rs/issues/177
 zstd-sys = "=2.0.1+zstd.1.5.2"
 futures = { version = "0.3.25", optional = true }
+async-std = { version = "1.12.0", optional = true, features = ["tokio1"] }
 
 [dev-dependencies]
 rsa = { version = "0.7" }
@@ -56,10 +56,9 @@ reqwest = { version = "0.11.10", features = ["blocking"] }
 
 
 [features]
-default = ["signature-pgp", "async-futures", "async-tokio"]
+default = ["signature-pgp", "async-futures"]
 
 signature-pgp = ["signature-meta", "pgp"]
 signature-meta = []
 test-with-podman = ["signature-meta"]
-async-tokio = ["tokio/fs"]
-async-futures = ["futures"]
+async-futures = ["futures", "async-std"]

--- a/src/compat_tests.rs
+++ b/src/compat_tests.rs
@@ -25,7 +25,7 @@ use signature::{self, Verifying};
 mod pgp {
     use super::*;
     use signature::pgp::{Signer, Verifier};
-    use tokio::io::AsyncWriteExt;
+    use AsyncWriteExt;
 
     #[tokio::test]
     #[serial_test::serial]

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -130,6 +130,8 @@ impl RPMBuilder {
         self
     }
 
+    // TODO: Should there be different providers of this interface? Currently
+    // requires a tokio runtime.
     #[cfg(feature = "async-tokio")]
     pub async fn with_file_async<T, P>(mut self, source: P, options: T) -> Result<Self, RPMError>
     where

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -1,8 +1,8 @@
 use nom::bytes::complete;
 use nom::number::complete::{be_i16, be_i32, be_i64, be_i8, be_u32, be_u8};
 
-#[cfg(feature = "async-tokio")]
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "async-futures")]
+use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::constants::{self, *};
 use chrono::offset::TimeZone;
@@ -45,7 +45,7 @@ impl<T> Header<T>
 where
     T: Tag,
 {
-    #[cfg(feature = "async-tokio")]
+    #[cfg(feature = "async-futures")]
     pub(crate) async fn parse_async<I: AsyncRead + Unpin>(
         input: &mut I,
     ) -> Result<Header<T>, RPMError> {
@@ -137,8 +137,8 @@ where
         Self::parse_header(index_header, &buf[..])
     }
 
-    #[cfg(feature = "async-tokio")]
-    pub(crate) async fn write_async<W: tokio::io::AsyncWrite + Unpin>(
+    #[cfg(feature = "async-futures")]
+    pub(crate) async fn write_async<W: AsyncWrite + Unpin>(
         &self,
         out: &mut W,
     ) -> Result<(), RPMError> {
@@ -329,7 +329,7 @@ impl Header<IndexSignatureTag> {
         SignatureHeaderBuilder::<Empty>::new()
     }
 
-    #[cfg(feature = "async-tokio")]
+    #[cfg(feature = "async-futures")]
     pub(crate) async fn parse_signature_async<I: AsyncRead + Unpin>(
         input: &mut I,
     ) -> Result<Header<IndexSignatureTag>, RPMError> {
@@ -359,8 +359,8 @@ impl Header<IndexSignatureTag> {
         Ok(result)
     }
 
-    #[cfg(feature = "async-tokio")]
-    pub(crate) async fn write_signature_async<W: tokio::io::AsyncWrite + Unpin>(
+    #[cfg(feature = "async-futures")]
+    pub(crate) async fn write_signature_async<W: AsyncWrite + Unpin>(
         &self,
         out: &mut W,
     ) -> Result<(), RPMError> {
@@ -798,8 +798,8 @@ impl IndexHeader {
         Ok(())
     }
 
-    #[cfg(feature = "async-tokio")]
-    pub(crate) async fn write_async<W: tokio::io::AsyncWrite + Unpin>(
+    #[cfg(feature = "async-futures")]
+    pub(crate) async fn write_async<W: AsyncWrite + Unpin>(
         &self,
         out: &mut W,
     ) -> Result<(), RPMError> {
@@ -869,8 +869,8 @@ impl<T: num::FromPrimitive + num::ToPrimitive + fmt::Debug + TypeName> IndexEntr
         ))
     }
 
-    #[cfg(feature = "async-tokio")]
-    pub(crate) async fn write_index_async<W: tokio::io::AsyncWrite + Unpin>(
+    #[cfg(feature = "async-futures")]
+    pub(crate) async fn write_index_async<W: AsyncWrite + Unpin>(
         &self,
         out: &mut W,
     ) -> Result<(), RPMError> {

--- a/src/rpm/headers/lead.rs
+++ b/src/rpm/headers/lead.rs
@@ -5,8 +5,8 @@ use std::convert::TryInto;
 use crate::constants::*;
 use crate::errors::*;
 
-#[cfg(feature = "async-tokio")]
-use tokio::io::AsyncWriteExt;
+#[cfg(feature = "async-futures")]
+use futures::io::{AsyncWrite, AsyncWriteExt};
 
 /// Lead of an rpm header.
 ///
@@ -107,8 +107,8 @@ impl Lead {
             reserved: rest.try_into().unwrap(),
         })
     }
-    #[cfg(feature = "async-tokio")]
-    pub(crate) async fn write_async<W: tokio::io::AsyncWrite + Unpin>(
+    #[cfg(feature = "async-futures")]
+    pub(crate) async fn write_async<W: AsyncWrite + Unpin>(
         &self,
         out: &mut W,
     ) -> Result<(), RPMError> {

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "async-tokio")]
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "async-futures")]
+use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::headers::*;
 
@@ -32,7 +32,7 @@ pub struct RPMPackage {
 }
 
 impl RPMPackage {
-    #[cfg(feature = "async-tokio")]
+    #[cfg(feature = "async-futures")]
     pub async fn parse_async<I: AsyncRead + Unpin>(input: &mut I) -> Result<Self, RPMError> {
         let metadata = RPMPackageMetadata::parse_async(input).await?;
         let mut content = Vec::new();
@@ -53,11 +53,8 @@ impl RPMPackage {
         Ok(())
     }
 
-    #[cfg(feature = "async-tokio")]
-    pub async fn write_async<W: tokio::io::AsyncWrite + Unpin>(
-        &self,
-        out: &mut W,
-    ) -> Result<(), RPMError> {
+    #[cfg(feature = "async-futures")]
+    pub async fn write_async<W: AsyncWrite + Unpin>(&self, out: &mut W) -> Result<(), RPMError> {
         self.metadata.write_async(out).await?;
         out.write_all(&self.content).await?;
         Ok(())
@@ -175,7 +172,7 @@ pub struct RPMPackageMetadata {
 }
 
 impl RPMPackageMetadata {
-    #[cfg(feature = "async-tokio")]
+    #[cfg(feature = "async-futures")]
     pub async fn parse_async<T: AsyncRead + Unpin>(input: &mut T) -> Result<Self, RPMError> {
         let mut lead_buffer = [0; LEAD_SIZE];
         input.read_exact(&mut lead_buffer).await?;
@@ -209,11 +206,8 @@ impl RPMPackageMetadata {
         Ok(())
     }
 
-    #[cfg(feature = "async-tokio")]
-    pub async fn write_async<W: tokio::io::AsyncWrite + Unpin>(
-        &self,
-        out: &mut W,
-    ) -> Result<(), RPMError> {
+    #[cfg(feature = "async-futures")]
+    pub async fn write_async<W: AsyncWrite + Unpin>(&self, out: &mut W) -> Result<(), RPMError> {
         self.lead.write_async(out).await?;
         self.signature.write_signature_async(out).await?;
         self.header.write_async(out).await?;

--- a/src/rpm/signature/pgp.rs
+++ b/src/rpm/signature/pgp.rs
@@ -276,7 +276,7 @@ pub(crate) mod test {
         let (signer, verifier) = prep();
         let (signing_key, verification_key) = { (signer.secret_key, verifier.public_key) };
 
-        let passwd_fn = || String::new();
+        let passwd_fn = String::new;
 
         let digest = &RPM_SHA2_256[..];
 
@@ -330,7 +330,7 @@ pub(crate) mod test {
         let data = [1u8; 322];
         let data = &data[..];
 
-        let passwd_fn = || String::new();
+        let passwd_fn = String::new;
 
         let now = now();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -319,8 +319,10 @@ async fn test_rpm_header_async() -> Result<(), Box<dyn std::error::Error>> {
     test_rpm_header_base(package)
 }
 
-#[cfg(feature = "async-tokio")]
+#[cfg(feature = "async-futures")]
 #[tokio::test]
+// By running this test inside the tokio runtime it validates that
+// the internal use of `async_std::fs::File` works.
 async fn test_rpm_builder_async() -> Result<(), Box<dyn std::error::Error>> {
     use std::str::FromStr;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+
+#[cfg(feature = "async-futures")]
+use tokio_util::compat::TokioAsyncReadCompatExt;
+
 #[cfg(feature = "signature-meta")]
 use crate::signature::pgp::{Signer, Verifier};
 
@@ -306,12 +310,11 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
-#[cfg(feature = "async-tokio")]
+#[cfg(feature = "async-futures")]
 #[tokio::test]
 async fn test_rpm_header_async() -> Result<(), Box<dyn std::error::Error>> {
     let rpm_file_path = test_rpm_file_path();
-
-    let mut rpm_file = tokio::fs::File::open(rpm_file_path).await?;
+    let mut rpm_file = tokio::fs::File::open(rpm_file_path).await?.compat();
     let package = RPMPackage::parse_async(&mut rpm_file).await?;
     test_rpm_header_base(package)
 }
@@ -372,7 +375,7 @@ fn test_region_tag() -> Result<(), Box<dyn std::error::Error>> {
 
     let data = possible_binary.unwrap();
 
-    let (_, entry) = IndexEntry::<IndexSignatureTag>::parse(&data)?;
+    let (_, entry) = IndexEntry::<IndexSignatureTag>::parse(data)?;
 
     assert_eq!(entry.tag, IndexSignatureTag::HEADER_SIGNATURES);
     assert_eq!(entry.data.to_u32(), IndexData::Bin(Vec::new()).to_u32());


### PR DESCRIPTION
For discussion. It was pretty trivial to replace `tokio`'s Async traits with `futures`, apart from the `builder` which uses tokio to async-read the files under the covers. Not sure what improvements can be made here though (also have an `async_std::fs::File` version?)