### PR TITLE
gh: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+<!--
+Thank you for submitting a PR to the rust rpm implementation!
+-->
+
+# PR Content Desc
+
+<!---
+DELETE all that do not apply:
+-->
+
+- 🩹 Bug Fix
+- 🦚 Feature
+- 📙 Documentation
+- 🦣 Legacy
+- 🪣 Misc
+
+<!---
+Mention the linked issue here.
+This will automatically close the issue once the PR is merged
+and creates a cross reference.
+-->
+
+Closes #
+
+## Changes proposed by this PR
+
+<!---
+Tell the reviewer WHAT changed, and WHY it had to change
+and how the WHAT and the WHY tie together.
+-->
+
+## Notes to reviewer
+
+<!---
+Leave a message to whoever is going to review this PR.
+Mainly, pointers to review the PR, and how they can test it.
+If things are still WIP or feedback on particular impl details
+are wanted, state them here too.
+-->
+
+## 📜 Checklist
+
+- [ ] Test coverage is excellent and passes
+- [ ] Works when tests are run `--all-features` enabled
+- [ ] Documentation is thorough

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -152,7 +152,7 @@ impl From<FileMode> for u32 {
 
 impl From<FileMode> for u16 {
     fn from(mode: FileMode) -> Self {
-        mode.raw_mode() as u16
+        mode.raw_mode()
     }
 }
 


### PR DESCRIPTION
Adds a pull request template for github, to provide a standard set of contextual information to ease the review process and avoid delays due to information retrieval.