### PR TITLE
Remove get_file_ima_signature_length()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed a couple of APIs to use unsigned integers instead of signed integers where appropriate
 - Moved pre-defined helpers for common package metadata (such as name, version, file lists, etc.)
   from `$pkg.metadata.header` to `$pkg.metadata`
+- Removed the `$pkg.metadata.get_file_ima_signature_length()` function
 
 ### Added
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -223,18 +223,6 @@ impl RPMPackageMetadata {
     }
 
     #[inline]
-    pub fn get_file_ima_signatures(&self) -> Result<&[String], RPMError> {
-        self.signature
-            .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
-    }
-
-    #[inline]
-    pub fn get_file_ima_signature_length(&self) -> Result<u32, RPMError> {
-        self.signature
-            .get_entry_data_as_u32(IndexSignatureTag::RPMSIGTAG_FILESIGNATURE_LENGTH)
-    }
-
-    #[inline]
     pub fn is_source_package(&self) -> bool {
         self.header
             .get_entry_data_as_u32(IndexTag::RPMTAG_SOURCEPACKAGE)
@@ -333,6 +321,12 @@ impl RPMPackageMetadata {
     pub fn get_file_checksums(&self) -> Result<&[String], RPMError> {
         self.header
             .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEDIGESTS)
+    }
+
+    #[inline]
+    pub fn get_file_ima_signatures(&self) -> Result<&[String], RPMError> {
+        self.signature
+            .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
     }
 
     /// Extract a the set of contained file names.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,9 +45,7 @@ fn test_rpm_file_signatures() -> Result<(), Box<dyn std::error::Error>> {
     let metadata = &package.metadata;
 
     let signatures = metadata.get_file_ima_signatures()?;
-    let signatures_length = metadata.get_file_ima_signature_length()?;
 
-    assert_eq!(signatures_length, 80);
     assert_eq!(
         signatures,
         [


### PR DESCRIPTION
Remove the helper function `get_file_ima_signature_length` after a discussion with RPM developers - the tag should be considered obsolete and therefore we ought not to encourage its use with a helper.

https://github.com/rpm-software-management/rpm/commit/b7e9a60370d910febbe8c69e2d2cac7512051eb3

- 🦣 Legacy
- 🪣 Misc