### PR TITLE
Add optional fields vendor and repository to RPMBuilder. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Forked from `rpm-rs` at version 0.8.1
 - Relicensed as MIT + Apache 2.0 after obtaining consent from all contributors
 - Added additional helper methods for retrieving commonly used metadata
+- Add vendor, url and vcs metadata optional fields to RPMBuilder
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ let pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome p
             .add_changelog_entry("you", "yeah, it was", 12312312)
             .requires(Dependency::any("wget"))
             .build_and_sign(Signer::load_from_asc_bytes(&raw_secret_key)?)
+            .vendor("corporation or individual")
+            .url("www.github.com/repo")
+            .vcs("git:repo=example_repo:branch=example_branch:sha=example_sha")
 let mut f = std::fs::File::create("./awesome.rpm")?;
 pkg.write(&mut f)?;
 

--- a/src/compat_tests.rs
+++ b/src/compat_tests.rs
@@ -85,6 +85,9 @@ mod pgp {
             .add_changelog_entry("me", "was awesome, eh?", 123_123_123)
             .add_changelog_entry("you", "yeah, it was", 12_312_312)
             .requires(Dependency::any("rpm-sign".to_string()))
+            .vendor("dummy vendor")
+            .url("dummy url")
+            .vcs("dummy vcs")
             .build_and_sign(signer)?;
 
         pkg.write_async(&mut f).await?;
@@ -183,6 +186,9 @@ mod pgp {
             .add_changelog_entry("me", "was awesome, eh?", 123_123_123)
             .add_changelog_entry("you", "yeah, it was", 12_312_312)
             .requires(Dependency::any("rpm-sign".to_string()))
+            .vendor("dummy vendor")
+            .url("dummy repo")
+            .vcs("git:repo=example_repo:branch=example_branch:sha=example_sha")
             .build_and_sign(signer)?;
 
         pkg.write(&mut f)?;

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -92,6 +92,10 @@ pub struct RPMBuilder {
     changelog_entries: Vec<String>,
     changelog_times: Vec<u32>,
     compressor: Compressor,
+
+    vendor: Option<String>,
+    url: Option<String>,
+    vcs: Option<String>,
 }
 
 impl RPMBuilder {
@@ -120,7 +124,24 @@ impl RPMBuilder {
             changelog_times: Vec::new(),
             compressor: Compressor::None(Vec::new()),
             directories: BTreeSet::new(),
+            vendor: None,
+            url: None,
+            vcs: None,
         }
+    }
+
+    pub fn vendor<T: Into<String>>(mut self, content: T) -> Self {
+        self.vendor = Some(content.into());
+        self
+    }
+    pub fn url<T: Into<String>>(mut self, content: T) -> Self {
+        self.url = Some(content.into());
+        self
+    }
+
+    pub fn vcs<T: Into<String>>(mut self, content: T) -> Self {
+        self.vcs = Some(content.into());
+        self
     }
 
     pub fn epoch(mut self, epoch: u32) -> Self {
@@ -948,6 +969,30 @@ impl RPMBuilder {
                 IndexTag::RPMTAG_POSTUN,
                 offset,
                 IndexData::StringTag(post_uninst_script),
+            ));
+        }
+
+        if let Some(vendor) = self.vendor {
+            actual_records.push(IndexEntry::new(
+                IndexTag::RPMTAG_VENDOR,
+                offset,
+                IndexData::StringTag(vendor),
+            ));
+        }
+
+        if let Some(url) = self.url {
+            actual_records.push(IndexEntry::new(
+                IndexTag::RPMTAG_URL,
+                offset,
+                IndexData::StringTag(url),
+            ));
+        }
+
+        if let Some(vcs) = self.vcs {
+            actual_records.push(IndexEntry::new(
+                IndexTag::RPMTAG_VCS,
+                offset,
+                IndexData::StringTag(vcs),
             ));
         }
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -268,6 +268,11 @@ impl RPMPackageMetadata {
     }
 
     #[inline]
+    pub fn get_vcs(&self) -> Result<&str, RPMError> {
+        self.header.get_entry_data_as_string(IndexTag::RPMTAG_VCS)
+    }
+
+    #[inline]
     pub fn get_license(&self) -> Result<&str, RPMError> {
         self.header
             .get_entry_data_as_string(IndexTag::RPMTAG_LICENSE)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -96,6 +96,13 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
         package.metadata.get_url().unwrap(),
         "https://www.port389.org/"
     );
+
+    // TODO: vcs
+    // assert_eq!(
+    //     package.metadata.get_vcs().unwrap(),
+    //     "git://pkgs.fedoraproject.org/389-ds-base.git"
+    // );
+
     assert_eq!(
         package.metadata.get_packager().unwrap(),
         "CentOS BuildSystem <http://bugs.centos.org>"
@@ -391,6 +398,9 @@ async fn test_rpm_builder_async() -> Result<(), Box<dyn std::error::Error>> {
         .add_changelog_entry("me", "was awesome, eh?", 123123123)
         .add_changelog_entry("you", "yeah, it was", 12312312)
         .requires(Dependency::any("wget"))
+        .vendor("dummy vendor")
+        .url("dummy url")
+        .vcs("dummy vcs")
         .build()?;
 
     pkg.write(&mut buff)?;


### PR DESCRIPTION
- 🦚 Feature

## Changes proposed by this PR

Adds optional fields vendor and repository to RPMBuilder. 
This allows for proper component governance and attribution of rpms.

## Notes to reviewer

Tests
Added vendor and repository fields to the create full rpm tests and passes as expected.

## 📜 Checklist

- [x] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled (works on cargo test and for each feature individually but not --all-features. The repo in the current state does not pass with cargo test --all-features due to a clash of #with-file-async-tokio and #with-file-async-async-std
- [x] Documentation is thorough
