### PR TITLE
Allow `cargo build --all-features` to work by preferring tokio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           - stable
           - 1.60.0
         flags:
+          - "--all-features"
           - "--no-default-features"
           - "--no-default-features --features signature-pgp,async-futures,with-file-async-async-std"
     steps:

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -44,7 +44,11 @@ async fn async_file_mode(file: &tokio::fs::File) -> Result<u32, RPMError> {
     Ok(file.metadata().await?.permissions().mode())
 }
 
-#[cfg(all(unix, feature = "with-file-async-async-std"))]
+#[cfg(all(
+    unix,
+    feature = "with-file-async-async-std",
+    not(feature = "with-file-async-tokio")
+))]
 async fn async_file_mode(file: &async_std::fs::File) -> Result<u32, RPMError> {
     Ok(file.metadata().await?.permissions().mode())
 }
@@ -54,7 +58,11 @@ async fn async_file_mode(_file: &tokio::fs::File) -> Result<u32, RPMError> {
     Ok(0)
 }
 
-#[cfg(all(windows, feature = "with-file-async-async-std"))]
+#[cfg(all(
+    windows,
+    feature = "with-file-async-async-std",
+    not(feature = "with-file-async-tokio")
+))]
 async fn async_file_mode(_file: &async_std::fs::File) -> Result<u32, RPMError> {
     Ok(0)
 }
@@ -188,7 +196,10 @@ impl RPMBuilder {
             .await
     }
 
-    #[cfg(feature = "with-file-async-async-std")]
+    #[cfg(all(
+        feature = "with-file-async-async-std",
+        not(feature = "with-file-async-tokio")
+    ))]
     pub async fn with_file_async<T, P>(self, source: P, options: T) -> Result<Self, RPMError>
     where
         P: AsRef<Path>,


### PR DESCRIPTION
# PR Content Desc

If both `with-file-async-tokio` and `with-file-async-async-std` are both specified, then prefer tokio over async-std.

- 🩹 Bug Fix

## Changes proposed by this PR

Add some feature flag gating that prevents duplicate definitions if --all-features is defined.

## 📜 Checklist

- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
- [ ] Documentation is thorough
