### PR TITLE
Remove async support from default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy
 
-      - run: cargo clippy ${{ matrix.flags }} -- -D warnings 
+      - run: cargo clippy ${{ matrix.flags }} -- -D warnings
       - run: cargo test ${{ matrix.flags }}
 
   compat-tests:
@@ -86,7 +86,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --features test-with-podman
+      - run: cargo test --features test-with-podman,with-file-async-tokio
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a `RPMPackage::open()` helper for working with files
+### Breaking Changes
+
+- Bump MSRV to 1.63.0
+- Removed async support from default features
 
 ## 0.9.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tokio = {version = "1", features = ["full"]}
 tokio-util = { version = "0.7.4", features = ["compat"]}
 
 [features]
-default = ["signature-pgp", "async-futures", "with-file-async-tokio"]
+default = ["signature-pgp"]
 
 signature-pgp = ["signature-meta", "pgp"]
 signature-meta = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ enum-display-derive = "0.1"
 cpio = "0.2"
 # consider migrating to flate2
 libflate = "1"
-sha2 = "0.10.2"
+sha2 = "0.10"
 md-5 = "0.10"
 sha1 = "0.10"
 rand = { version = "0.8" }
@@ -53,7 +53,6 @@ rsa = { version = "0.8" }
 rsa-der = { version = "^0.3.0" }
 env_logger = "0.10.0"
 serial_test = "1.0"
-reqwest = { version = "0.11.10", features = ["blocking"] }
 
 # Use for testing async files when async-futures enabled
 tokio = {version = "1", features = ["full"]}


### PR DESCRIPTION
Most users won't need it, and the dependencies it pulls in are very heavy.  Make it opt-in.

closes #89 