### PR TITLE
Support files >4gb, default to 64bit tag sizes for tag-related data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensured that digests are always added to built RPMs. Previously they would not be included unless
   the "signature-meta" (or "signature-pgp") features were enabled.
 - Added `PAYLOADDIGEST`, `PAYLOADDIGESTALT`, and `PAYLOADDIGESTALGO` tags to built packages.
-- To facilitate reproducible builds, stop writing `build_time` to the package by default.  Users can configure it with `RPMBuilder::build_time()`.
+- To facilitate reproducible builds, stop writing `build_time` to the package by default.
+  Users can configure it with `RPMBuilder::build_time()`.
+- Improved support for packages >4gb
 
 ### Breaking Changes
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -54,6 +54,8 @@ pub enum IndexTag {
     RPMTAG_LONGARCHIVESIZE = RPMTAG_SIG_BASE + 15,
 
     RPMTAG_SHA256HEADER = RPMTAG_SIG_BASE + 17,
+    RPMTAG_VERITYSIGNATURES = RPMTAG_SIG_BASE + 20,
+    RPMTAG_VERITYSIGNATUREALGO = RPMTAG_SIG_BASE + 21,
 
     RPMTAG_NAME = 1000,
     RPMTAG_VERSION = 1001,
@@ -394,10 +396,10 @@ pub enum IndexSignatureTag {
     RPMSIGTAG_RSA = 268,
 
     /// Size of combined header and payload if > 4GB.
-    RPMSIGTAG_LONGSIGSIZE = 270,
+    RPMSIGTAG_LONGSIZE = 270,
 
     /// (Compressed) payload size when > 4GB.
-    RPMSIGTAG_LONGARCHIVESIZE = 271,
+    RPMSIGTAG_LONGARCHIVESIZE = IndexTag::RPMTAG_LONGARCHIVESIZE as u32,
 
     /// The tag contains the file signature of a file.
     /// The data is formatted as a hex-encoded string.
@@ -407,6 +409,11 @@ pub enum IndexSignatureTag {
     /// The tag contains the length of the file signatures in total.
     /// If this tag is present, then the SIGTAG_FILESIGNATURE shall also be present.
     RPMSIGTAG_FILESIGNATURE_LENGTH = 275,
+
+    /// FSVerity signatures of files.
+    RPMSIGTAG_VERITYSIGNATURES = IndexTag::RPMTAG_VERITYSIGNATURES as u32,
+    /// Algorithm used for FSVerity signatures.
+    RPMSIGTAG_VERITYSIGNATUREALGO = IndexTag::RPMTAG_VERITYSIGNATUREALGO as u32,
 
     /// This tag specifies the RSA signature of the combined Header and Payload sections.
     /// The data is formatted as a Version 3 Signature Packet as specified in RFC 2440: OpenPGP Message Format.

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -314,7 +314,7 @@ impl Header<IndexSignatureTag> {
     /// Please use the [`builder`](Self::builder()) which has modular and safe API.
     #[cfg(feature = "signature-meta")]
     pub(crate) fn new_signature_header(
-        headers_plus_payload_size: u32,
+        headers_plus_payload_size: usize,
         md5sum: &[u8],
         sha1: &str,
         rsa_spanning_header: &[u8],
@@ -962,7 +962,7 @@ mod test {
     #[cfg(feature = "signature-meta")]
     #[test]
     fn signature_header_build() {
-        let size: u32 = 209_348;
+        let size: u64 = 209_348;
         let md5sum: &[u8] = &[22u8; 16];
         let sha1 = "5A884F0CB41EC3DA6D6E7FC2F6AB9DECA8826E8D";
         let rsa_spanning_header: &[u8] = b"111222333444";
@@ -972,9 +972,9 @@ mod test {
             let offset = 0;
             let entries = vec![
                 IndexEntry::new(
-                    IndexSignatureTag::RPMSIGTAG_SIZE,
+                    IndexSignatureTag::RPMSIGTAG_LONGSIZE,
                     offset,
-                    IndexData::Int32(vec![size]),
+                    IndexData::Int64(vec![size]),
                 ),
                 // TODO consider dropping md5 in favour of sha256
                 IndexEntry::new(
@@ -1002,7 +1002,7 @@ mod test {
         };
 
         let built = Header::<IndexSignatureTag>::new_signature_header(
-            size,
+            size as usize,
             md5sum,
             sha1,
             rsa_spanning_header,

--- a/src/rpm/headers/signature_builder.rs
+++ b/src/rpm/headers/signature_builder.rs
@@ -56,13 +56,13 @@ where
     T: ConstructionStage,
 {
     /// Construct the complete signature header.
-    pub fn build(mut self, headers_plus_payload_size: u32) -> Header<IndexSignatureTag> {
+    pub fn build(mut self, headers_plus_payload_size: usize) -> Header<IndexSignatureTag> {
         self.entries.insert(
             0,
             IndexEntry::new(
-                IndexSignatureTag::RPMSIGTAG_SIZE,
+                IndexSignatureTag::RPMSIGTAG_LONGSIZE,
                 0i32, // externally filled
-                IndexData::Int32(vec![headers_plus_payload_size]),
+                IndexData::Int64(vec![headers_plus_payload_size as u64]),
             ),
         );
 

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -15,7 +15,7 @@ pub struct RPMPackageSegmentOffsets {
 
 /// Describes a file present in the rpm file.
 pub struct RPMFileEntry {
-    pub(crate) size: u32,
+    pub(crate) size: u64,
     pub(crate) mode: FileMode,
     pub(crate) modified_at: u32,
     pub(crate) sha_checksum: String,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,7 +60,7 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
         "x86-01.bsys.centos.org"
     );
     assert_eq!(package.metadata.get_build_time().unwrap(), 1540945151);
-
+    assert_eq!(package.metadata.get_installed_size().unwrap(), 503853);
     assert_eq!(package.metadata.get_payload_compressor().unwrap(), "xz");
 
     assert_eq!(package.metadata.is_source_package(), false);

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -81,15 +81,14 @@ mod pgp {
         let epoch = pkg.metadata.get_epoch()?;
         assert_eq!(1, epoch);
 
-        let yum_cmd = "yum --disablerepo=updates,updates-testing,updates-modular,fedora-modular install -y /out/test.rpm;";
         let dnf_cmd = "dnf --disablerepo=updates,updates-testing,updates-modular,fedora-modular install -y /out/test.rpm;";
         let rpm_sig_check = "rpm -vv --checksig /out/test.rpm 2>&1;".to_string();
 
         [
-            ("fedora:36", rpm_sig_check.as_str()),
-            ("fedora:36", dnf_cmd),
-            ("centos:stream9", yum_cmd),
-            ("centos:7", yum_cmd),
+            ("fedora:38", rpm_sig_check.as_str()),
+            ("fedora:38", dnf_cmd),
+            ("centos:stream9", dnf_cmd),
+            ("centos:stream8", dnf_cmd),
         ]
         .iter()
         .try_for_each(|(image, cmd)| {
@@ -106,13 +105,12 @@ mod pgp {
 
         let mut f = std::fs::File::create(out_file)?;
         pkg.write(&mut f)?;
-        let yum_cmd = "yum --disablerepo=updates,updates-testing,updates-modular,fedora-modular install -y /out/test.rpm;";
         let dnf_cmd = "dnf --disablerepo=updates,updates-testing,updates-modular,fedora-modular install -y /out/test.rpm;";
 
         [
-            ("fedora:36", dnf_cmd),
-            ("centos:stream9", yum_cmd),
-            ("centos:7", yum_cmd),
+            ("fedora:38", dnf_cmd),
+            ("centos:stream9", dnf_cmd),
+            ("centos:stream8", dnf_cmd),
         ]
         .iter()
         .try_for_each(|(image, cmd)| {
@@ -189,15 +187,14 @@ mod pgp {
         let epoch = pkg.metadata.get_epoch()?;
         assert_eq!(1, epoch);
 
-        let yum_cmd = "yum --disablerepo=updates,updates-testing,updates-modular,fedora-modular install -y /out/test.rpm;";
         let dnf_cmd = "dnf --disablerepo=updates,updates-testing,updates-modular,fedora-modular install -y /out/test.rpm;";
         let rpm_sig_check = "rpm -vv --checksig /out/test.rpm 2>&1;".to_string();
 
         [
-            ("fedora:36", rpm_sig_check.as_str()),
-            ("fedora:36", dnf_cmd),
-            ("centos:stream9", yum_cmd),
-            ("centos:7", yum_cmd),
+            ("fedora:38", rpm_sig_check.as_str()),
+            ("fedora:38", dnf_cmd),
+            ("centos:stream9", dnf_cmd),
+            ("centos:stream8", dnf_cmd),
         ]
         .iter()
         .try_for_each(|(image, cmd)| {
@@ -295,7 +292,7 @@ rpm -vv --checksig /out/{rpm_file} 2>&1
             rpm_file = out_file.file_name().unwrap().to_str().unwrap()
         );
 
-        podman_container_launcher(cmd.as_str(), "fedora:36", vec![])?;
+        podman_container_launcher(cmd.as_str(), "fedora:38", vec![])?;
 
         let out_file = std::fs::File::open(&out_file).expect("should be able to open rpm file");
         let mut buf_reader = std::io::BufReader::new(out_file);
@@ -345,7 +342,7 @@ gpg --verify /out/test.file.sig /out/test.file 2>&1
 
 "#.to_owned();
 
-        podman_container_launcher(cmd.as_str(), "fedora:36", vec![])
+        podman_container_launcher(cmd.as_str(), "fedora:38", vec![])
             .expect("Container execution must be flawless");
 
         let verifier =


### PR DESCRIPTION
Use 64bit file tags to support file sizes >4gb.  All versions of `rpm` starting with 4.6.0 (circa 2008) support and look for the 64bit tags by default so there is little reason to support the fallback logic.

- 🩹 Bug Fix
- 🦚 Feature
- 🦣 Legacy

closes #65