### PR TITLE
Streamline pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,45 +1,23 @@
-<!--
+<!---
 Thank you for submitting a PR to the rust rpm implementation!
--->
 
-# PR Content Desc
-
-<!---
-DELETE all that do not apply:
--->
-
-- 🩹 Bug Fix
-- 🦚 Feature
-- 📙 Documentation
-- 🦣 Legacy
-- 🪣 Misc
-
-<!---
-Mention the linked issue here.
-This will automatically close the issue once the PR is merged
-and creates a cross reference.
--->
-
-Closes #
-
-## Changes proposed by this PR
-
-<!---
-Tell the reviewer WHAT changed, and WHY it had to change
+Commits should be distinct and have a clear purpose, with messages
+which explain to the reviewer WHAT changed, and WHY it had to change
 and how the WHAT and the WHY tie together.
--->
 
-## Notes to reviewer
+At the bottom of your commit messages, add a line "Closes #IssueNumber)"
+for any issues resolved by the commit, substituting in an actual issue number.
+This will automatically close the issue once the PR is merged and creates a
+cross reference.
 
-<!---
-Leave a message to whoever is going to review this PR.
-Mainly, pointers to review the PR, and how they can test it.
 If things are still WIP or feedback on particular impl details
-are wanted, state them here too.
+are wanted, state them here or leave comments below.
 -->
 
-## 📜 Checklist
+### 📜 Checklist
 
+- [ ] Commits are cleanly separated and have useful messages
+- [ ] A changelog entry or entries has been added to CHANGELOG.md
+- [ ] Documentation is thorough
 - [ ] Test coverage is excellent and passes
 - [ ] Works when tests are run `--all-features` enabled
-- [ ] Documentation is thorough


### PR DESCRIPTION
The current PR template is very thorough but a bit overwhelming and overkill for most contributions, slimming it down a bit might be helpful.