### PR TITLE
Added RPMPackage::open()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a `RPMPackage::open()` helper for working with files
+
 ## 0.9.0
 
 ### Breaking Changes

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
 
 use chrono::offset::TimeZone;
 #[cfg(feature = "async-futures")]
@@ -34,6 +35,13 @@ pub struct RPMPackage {
 }
 
 impl RPMPackage {
+    /// Open and parse a file at the provided path as an RPM package.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, RPMError> {
+        let rpm_file = std::fs::File::open(path.as_ref())?;
+        let mut buf_reader = BufReader::new(rpm_file);
+        Self::parse(&mut buf_reader)
+    }
+
     #[cfg(feature = "async-futures")]
     pub async fn parse_async<I: AsyncRead + Unpin>(input: &mut I) -> Result<Self, RPMError> {
         let metadata = RPMPackageMetadata::parse_async(input).await?;


### PR DESCRIPTION
Adds a helper method that avoids making the user do buffer management for common use cases.

- 🦚 Feature