### PR TITLE
Add parsing Compressor and add compress feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and provenance of packages.
 - Added `get_package_segment_boundaries()` to `RPMPackage` to enable reading the raw bytes of the
   different components (header, payload, etc.) from an on-disk package.
+- Added `CompressionType`.
 
 ### Fixed
 
@@ -50,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `$pkg.metadata.get_payload_format()`. It is still possible to fetch manually, but
   practically speaking it is not meaningful. rpmbuild has written a misleading value here for
   10 years.
+- Added support for parsing `CompressionType` string in `RPMPackageMetadata`.
+- Changed signature for `RPMBuilder::compression`.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `get_package_segment_boundaries()` to `RPMPackage` to enable reading the raw bytes of the
   different components (header, payload, etc.) from an on-disk package.
 - Added `CompressionType`.
+- Added support for `xz` compression type
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ chrono = "0.4"
 log = "0.4"
 itertools = "0.10"
 hex = { version = "0.4", features = ["std"] }
-zstd = "0.12.0"
+zstd = "0.12"
+xz2 = "0.1"
 futures = { version = "0.3.25", optional = true }
 
 # Libraries required for with_file_async() implementations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! # {
 //! let raw_secret_key = std::fs::read("./test_assets/secret_key.asc")?;
 //! let pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
-//!             .compression(rpm::Compressor::from_str("gzip")?)
+//!             .compression(rpm::CompressionType::Gzip)
 //!             .with_file(
 //!                 "./test_assets/awesome.toml",
 //!                 rpm::RPMFileOptions::new("/etc/awesome/config.toml")

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -2,6 +2,7 @@ use std::io::BufReader;
 #[cfg(feature = "signature-meta")]
 use std::io::Seek;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use chrono::offset::TimeZone;
 
@@ -10,16 +11,15 @@ use digest::Digest;
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use num_traits::FromPrimitive;
 
-use super::headers::*;
-use super::Lead;
-
 use crate::constants::*;
 use crate::errors::*;
-
 use crate::sequential_cursor::SeqCursor;
-
 #[cfg(feature = "signature-meta")]
 use crate::signature;
+use crate::CompressionType;
+
+use super::headers::*;
+use super::Lead;
 
 /// Combined digest of signature header tags `RPMSIGTAG_MD5` and `RPMSIGTAG_SHA1`
 ///
@@ -650,9 +650,11 @@ impl RPMPackageMetadata {
     }
 
     #[inline]
-    pub fn get_payload_compressor(&self) -> Result<&str, RPMError> {
-        self.header
-            .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOADCOMPRESSOR)
+    pub fn get_payload_compressor(&self) -> Result<CompressionType, RPMError> {
+        let comp_str = self
+            .header
+            .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOADCOMPRESSOR)?;
+        CompressionType::from_str(comp_str)
     }
 
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -61,11 +61,10 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
     );
     assert_eq!(package.metadata.get_build_time().unwrap(), 1540945151);
     assert_eq!(package.metadata.get_installed_size().unwrap(), 503853);
-    assert!(matches!(
-        package.metadata.get_payload_compressor(),
-        Err(RPMError::UnknownCompressorType(xz)) if xz == "xz"
-    ));
-
+    assert_eq!(
+        package.metadata.get_payload_compressor().unwrap(),
+        CompressionType::Xz
+    );
 
     assert_eq!(package.metadata.is_source_package(), false);
 
@@ -209,11 +208,10 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
             payload: 148172
         }
     );
-    assert!(matches!(
-        metadata.get_payload_compressor(),
-        Err(RPMError::UnknownCompressorType(xz)) if xz == "xz"
-    ));
-
+    assert_eq!(
+        metadata.get_payload_compressor().unwrap(),
+        CompressionType::Xz
+    );
 
     let expected_file_checksums = vec![
         "",

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -12,7 +12,6 @@ use signature::{self, Verifying};
 mod pgp {
     use super::*;
     use signature::pgp::{Signer, Verifier};
-    use std::str::FromStr;
 
     #[serial_test::serial]
     fn create_full_rpm() -> Result<(), Box<dyn std::error::Error>> {
@@ -27,7 +26,7 @@ mod pgp {
 
         let mut f = File::create(out_file)?;
         let pkg = RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some package")
-            .compression(Compressor::from_str("gzip")?)
+            .compression(CompressionType::Gzip)
             .with_file(
                 cargo_file.to_str().unwrap(),
                 RPMFileOptions::new("/etc/foobar/foo.toml"),
@@ -134,7 +133,7 @@ mod pgp {
 
         let mut f = std::fs::File::create(out_file)?;
         let pkg = RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some package")
-            .compression(Compressor::from_str("gzip")?)
+            .compression(CompressionType::Gzip)
             .with_file(
                 cargo_file.to_str().unwrap(),
                 RPMFileOptions::new("/etc/foobar/foo.toml"),
@@ -223,7 +222,7 @@ mod pgp {
                 "x86_64",
                 "spins round and round",
             )
-            .compression(Compressor::from_str("gzip")?)
+            .compression(CompressionType::Gzip)
             .with_file(
                 cargo_file.to_str().unwrap(),
                 RPMFileOptions::new("/etc/foobar/hugo/bazz.toml")

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -46,9 +46,9 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
         f.read_exact(&mut buf)?;
 
         let payload_magic: &[u8] = match package.metadata.get_payload_compressor().ok() {
-            Some("gzip") => &[0x1f, 0x8b],
-            Some("zstd") => &[0x28, 0xb5, 0x2f, 0xfd],
-            Some("xz") => &[0xfd, 0x37, 0x7a, 0x58, 0x5a],
+            Some(CompressionType::Gzip) => &[0x1f, 0x8b],
+            Some(CompressionType::Zstd) => &[0x28, 0xb5, 0x2f, 0xfd],
+            Some(CompressionType::Xz) => &[0xfd, 0x37, 0x7a, 0x58, 0x5a],
             None => &[0x30, 0x37, 0x30, 0x37, 0x30, 0x31], // CPIO archive magic #
             a => unimplemented!("{:?}", a),
         };

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -2,8 +2,6 @@ use rpm::chrono::TimeZone;
 use rpm::signature::pgp::{Signer, Verifier};
 use rpm::*;
 
-use std::str::FromStr;
-
 mod common;
 
 #[test]
@@ -43,7 +41,7 @@ fn parse_externally_signed_rpm_and_verify() -> Result<(), Box<dyn std::error::Er
             "x86_64",
             "spins round and round",
         )
-        .compression(Compressor::from_str("gzip")?)
+        .compression(CompressionType::Gzip)
         .with_file(
             cargo_file.to_str().unwrap(),
             RPMFileOptions::new("/etc/foobar/hugo/bazz.toml")


### PR DESCRIPTION
<!--
Thank you for submitting a PR to the rust rpm implementation!
-->

# PR Content Desc

- [x] Add support for parsing `Compressor` string in `RPMPackageMetadata`
- [x] Add Cargo feature for enable or disable compress feature 

<!---
DELETE all that do not apply:
-->

- 🦚 Feature

<!---
Mention the linked issue here.
This will automatically close the issue once the PR is merged
and creates a cross reference.
-->

Closes #

## Changes proposed by this PR

<!---
Tell the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.
-->

## Notes to reviewer

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particular impl details
are wanted, state them here too.
-->

## 📜 Checklist

- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
- [x] Documentation is thorough
