### PR TITLE
Stop store content in memory for RPMBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! let raw_secret_key = std::fs::read("./test_assets/secret_key.asc")?;
 //! // It's recommended to use timestamp of last commit in your VCS
 //! let source_date = 1_600_000_000;
-//! let pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
+//! let mut pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
 //!     .compression(rpm::CompressionType::Gzip)
 //!     .with_file(
 //!         "./test_assets/awesome.toml",
@@ -67,7 +67,7 @@
 //!
 //! // reading
 //! let raw_pub_key = std::fs::read("test_assets/public_key.asc")?;
-//! let pkg = rpm::RPMPackage::open("/tmp/awesome.rpm")?;
+//! let mut pkg = rpm::RPMPackage::open("/tmp/awesome.rpm")?;
 //! // verifying
 //! pkg.verify_signature(Verifier::load_from_asc_bytes(&raw_pub_key)?)?;
 //! # }

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -328,7 +328,7 @@ impl Header<IndexSignatureTag> {
     /// Please use the [`builder`](Self::builder()) which has modular and safe API.
     #[cfg(feature = "signature-meta")]
     pub(crate) fn new_signature_header(
-        headers_plus_payload_size: usize,
+        headers_plus_payload_size: u64,
         md5sum: &[u8],
         sha1: &str,
         sha256: &str,
@@ -956,7 +956,7 @@ mod test {
         };
 
         let built = Header::<IndexSignatureTag>::new_signature_header(
-            size as usize,
+            size as u64,
             md5sum,
             sha1,
             sha256,

--- a/src/rpm/headers/signature_builder.rs
+++ b/src/rpm/headers/signature_builder.rs
@@ -56,7 +56,7 @@ where
     T: ConstructionStage,
 {
     /// Construct the complete signature header.
-    pub fn build(mut self, headers_plus_payload_size: usize) -> Header<IndexSignatureTag> {
+    pub fn build(mut self, headers_plus_payload_size: u64) -> Header<IndexSignatureTag> {
         let entry = match headers_plus_payload_size.try_into() {
             Ok(size) => IndexEntry::new(
                 IndexSignatureTag::RPMSIGTAG_SIZE,
@@ -66,7 +66,7 @@ where
             Err(_) => IndexEntry::new(
                 IndexSignatureTag::RPMSIGTAG_LONGSIZE,
                 0i32,
-                IndexData::Int64(vec![headers_plus_payload_size as u64]),
+                IndexData::Int64(vec![headers_plus_payload_size]),
             ),
         };
         self.entries.insert(0, entry);

--- a/src/rpm/mod.rs
+++ b/src/rpm/mod.rs
@@ -5,6 +5,7 @@ mod package;
 mod timestamp;
 
 pub mod signature;
+mod skip_reader;
 
 pub use headers::*;
 

--- a/src/rpm/skip_reader.rs
+++ b/src/rpm/skip_reader.rs
@@ -1,0 +1,44 @@
+use std::io;
+use std::io::SeekFrom;
+
+pub struct SkipReader<R> {
+    reader: R,
+    start_pos: u64,
+}
+
+impl<R: io::Read + io::Seek> SkipReader<R> {
+    pub(crate) fn new(mut reader: R) -> io::Result<Self> {
+        let start_pos = reader.stream_position()?;
+        Ok(Self { reader, start_pos })
+    }
+}
+
+impl<R: io::Seek> io::Seek for SkipReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        match pos {
+            SeekFrom::Start(p) => self.reader.seek(SeekFrom::Start(p + self.start_pos)),
+            SeekFrom::Current(p) => self
+                .reader
+                .seek(SeekFrom::Current(p + self.start_pos as i64)),
+            SeekFrom::End(p) => self
+                .reader
+                .seek(SeekFrom::Current(p + self.start_pos as i64)),
+        }
+    }
+}
+
+impl<R: io::Read> io::Read for SkipReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.reader.read(buf)
+    }
+}
+
+impl<R: io::BufRead> io::BufRead for SkipReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.reader.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.reader.consume(amt)
+    }
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -13,7 +13,7 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
     assert_boundaries(common::rpm_empty_path().as_ref())?;
     assert_boundaries(common::rpm_empty_source_path().as_ref())?;
 
-    let constructed_pkg = RPMBuilder::new("empty-package", "0", "MIT", "x86_64", "").build()?;
+    let mut constructed_pkg = RPMBuilder::new("empty-package", "0", "MIT", "x86_64", "").build()?;
     constructed_pkg.write(&mut File::create("/tmp/empty_pkg.rpm")?)?;
     assert_boundaries(Path::new("/tmp/empty_pkg.rpm"))?;
 
@@ -22,7 +22,7 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
         use rpm::signature::pgp::Signer;
         let (signing_key, _) = common::load_asc_keys();
         let signer = Signer::load_from_asc_bytes(signing_key.as_ref())?;
-        let constructed_pkg_with_sig =
+        let mut constructed_pkg_with_sig =
             RPMBuilder::new("empty-package", "0", "MIT", "x86_64", "").build_and_sign(signer)?;
         constructed_pkg_with_sig.write(&mut File::create("/tmp/empty_pkg_with_sig.rpm")?)?;
         assert_boundaries(Path::new("/tmp/empty_pkg_with_sig.rpm"))?;

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -33,7 +33,7 @@ fn parse_externally_signed_rpm_and_verify() -> Result<(), Box<dyn std::error::Er
         let signer = Signer::load_from_asc_bytes(signing_key.as_ref())?;
 
         let mut f = std::fs::File::create(&out_file)?;
-        let pkg = RPMBuilder::new(
+        let mut pkg = RPMBuilder::new(
             "roundtrip",
             "1.0.0",
             "MIT",
@@ -66,7 +66,7 @@ fn parse_externally_signed_rpm_and_verify() -> Result<(), Box<dyn std::error::Er
     {
         let out_file = std::fs::File::open(&out_file).expect("should be able to open rpm file");
         let mut buf_reader = std::io::BufReader::new(out_file);
-        let package = RPMPackage::parse(&mut buf_reader)?;
+        let mut package = RPMPackage::parse(&mut buf_reader)?;
 
         let verifier = Verifier::load_from_asc_bytes(verification_key.as_ref())?;
 


### PR DESCRIPTION
# PR Content Desc

At the moment, `RPMPackage` store content in memory. This is not good situation. I rewrite `RPMPackage` to generic struct.

If my idea is ok for maintainers, I will finish the PR.
<!---
DELETE all that do not apply:
-->

- 🦚 Feature
- 📙 Documentation
- 🦣 Legacy
- 🪣 Misc

<!---
Mention the linked issue here.
This will automatically close the issue once the PR is merged
and creates a cross reference.
-->

Closes #

## Changes proposed by this PR

<!---
Tell the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.
-->

## Notes to reviewer

<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
If things are still WIP or feedback on particular impl details
are wanted, state them here too.
-->

## 📜 Checklist

- [ ] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
- [x] Documentation is thorough
