### PR TITLE
Remove "Lead" from the public API and stop checking its fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump MSRV to 1.63.0
 - Removed async support from default features
+- Removed `Lead` from the public API. `Lead` is long-deprecated and shouldn't be relied on.
+  Restricted the data we write to `Lead` to the bare minimum required for compatibility.
 
 ## 0.9.0
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -49,21 +49,6 @@ pub enum RPMError {
     #[error("invalid tag value enum variant for {tag} with {variant}")]
     InvalidTagValueEnumVariant { tag: String, variant: u32 },
 
-    #[error("unsupported lead major version {0} - only version 3 is supported")]
-    InvalidLeadMajorVersion(u8),
-
-    #[error("unsupported lead major version {0} - only version 0 is supported")]
-    InvalidLeadMinorVersion(u8),
-
-    #[error("invalid type - expected 0 or 1 but got {0}")]
-    InvalidLeadPKGType(u16),
-
-    #[error("invalid os-type - expected 1 but got {0}")]
-    InvalidLeadOSType(u16),
-
-    #[error("invalid signature-type - expected 5 but got {0}")]
-    InvalidLeadSignatureType(u16),
-
     #[error("invalid size of reserved area - expected length of {expected} but got {actual}")]
     InvalidReservedSpaceSize { expected: u16, actual: usize },
 

--- a/src/rpm/headers/mod.rs
+++ b/src/rpm/headers/mod.rs
@@ -3,7 +3,7 @@ mod lead;
 mod types;
 
 pub use header::*;
-pub use lead::*;
+pub(crate) use lead::*;
 pub use types::*;
 
 #[cfg(feature = "signature-meta")]


### PR DESCRIPTION
# PR Content Desc

Lead has been deprecated upstream for a long time and the docs suggest not to read it.  There is a plan to stop populating its fields entirely, so we should stop trying to validate them.

closes #78

- 🦣 Legacy

## Notes to reviewer

See the references attached to the issue

## 📜 Checklist

- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
- [x] Documentation is thorough
