### PR TITLE
Drop cpio-rs, replace with vendored code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for ecdsa signatures
+- Added `Package::files()` for iterating over the files of an RPM package (metadata & contents).
 
 ## 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FileOptions::verify()`
 - Added `Evr` and `Nevra` structs and `rpm_evr_compare` function for comparing RPM versions.
 
+### Fixed
+
+- RPM packages that use large files (>4gb) now correctly declare rpmlib() dependency
+
 ### Changed
 
 - As RHEL 7 (thus, CentOS 7 and other derivatives) goes out-of-support on June 30, 2024, support for legacy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ itertools = "0.13"
 hex = { version = "0.4", features = ["std"] }
 zstd = { version = "0.13", optional = true }
 xz2 = { version = "0.1", optional = true }
-bzip2 = { version = "0.4.4", optional = true }
+bzip2 = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/src/rpm/filecaps.rs
+++ b/src/rpm/filecaps.rs
@@ -50,6 +50,14 @@ const CAPS: &[&str; 41] = &[
 #[derive(Debug, Clone)]
 pub struct FileCaps(String);
 
+impl FileCaps {
+    pub fn new(input: String) -> Result<Self, Error> {
+        validate_caps_text(&input)?;
+
+        Ok(Self(input))
+    }
+}
+
 impl Display for FileCaps {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
This is necessary because RPM uses a modified CPIO format to support
\>4gb file sizes. To maximize similarity and avoid producing nonsensical
RPM payloads, we should do the same.

closes #108

### 📜 Checklist

- [ ] Commits are cleanly separated and have useful messages
- [ ] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled
