### PR TITLE
Automatically set BUILDHOST and tag and add COOKIE tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.63.0
+          - 1.64.0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -59,7 +59,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.63.0
+          - 1.64.0
         flags:
           - "--all-features"
           - "--no-default-features"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `$pkg.metadata.get_changelog_entries()`
 - Added the following functions to `RPMBuilder` to support weak dependencies: `recommends()`,
   `suggests()`, `enhances()` and `supplements()`
+- Added the following additional functions to `RPMBuilder`: `cookie()`, `build_host()`
+- Added `get_build_cookie()` for use with `RPMBuilder::cookie()`
 - Added the following functions to `$pkg.metadata` for retrieval of various kinds of RPM
   dependencies: `get_provides()`, `get_requires()`, `get_obsoletes()`, `get_conflicts()`,
   `get_recommends()`, `get_suggests()`, `get_enhances()`, `get_supplements()`
@@ -32,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- Bump MSRV to 1.63.0
+- Bump MSRV to 1.64.0
 - Removed async support from default features
 - Removed `Lead` from the public API. `Lead` is long-deprecated and shouldn't be relied on.
   Restricted the data we write to `Lead` to the bare minimum required for compatibility.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/rpm-rs/rpm"
 readme = "README.md"
 keywords = ["RPM", "packaging"]
 categories = ["parsing", "development-tools"]
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 
 [lib]
 name = "rpm"
@@ -42,6 +42,7 @@ itertools = "0.10"
 hex = { version = "0.4", features = ["std"] }
 zstd = "0.12.0"
 futures = { version = "0.3.25", optional = true }
+gethostname = "0.4.1"
 
 # Libraries required for with_file_async() implementations
 async-std = { version = "1.12.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/rpm-rs/rpm"
 readme = "README.md"
 keywords = ["RPM", "packaging"]
 categories = ["parsing", "development-tools"]
-rust-version = "1.64.0"
+rust-version = "1.64.0"  # required by `gethosname`
 
 [lib]
 name = "rpm"

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -324,6 +324,12 @@ impl RPMPackageMetadata {
     }
 
     #[inline]
+    pub fn get_cookie(&self) -> Result<&str, RPMError> {
+        self.header
+            .get_entry_data_as_string(IndexTag::RPMTAG_COOKIE)
+    }
+
+    #[inline]
     pub fn get_source_rpm(&self) -> Result<&str, RPMError> {
         self.header
             .get_entry_data_as_string(IndexTag::RPMTAG_SOURCERPM)


### PR DESCRIPTION
Incremental improvement towards making an empty package built by rpm-r more similar to one created by rpmbuild

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
