### PR TITLE
Add a function for getting the boundaries between of the components of the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `get_entry_data_as_i18n_string()`
 - Added `verify_signature()` and `verify_digests()` to `RPMPackage` to enable checking the integrity
   and provenance of packages.
+- Added `get_package_segment_boundaries()` to `RPMPackage` to enable reading the raw bytes of the
+  different components (header, payload, etc.) from an on-disk package.
 
 ### Fixed
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -446,8 +446,12 @@ impl Tag for IndexSignatureTag {
     }
 }
 
-/// lead header size
-pub const LEAD_SIZE: usize = 96;
+/// Size (in bytes) of the package "lead" section
+pub const LEAD_SIZE: u32 = 96;
+/// Size (in bytes) of the index header (the fixed portion of each header)
+pub const INDEX_HEADER_SIZE: u32 = 16;
+/// Size (in bytes) of each entry in the index
+pub const INDEX_ENTRY_SIZE: u32 = 16;
 /// rpm magic as part of the lead header
 pub const RPM_MAGIC: [u8; 4] = [0xed, 0xab, 0xee, 0xdb];
 

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -294,6 +294,14 @@ where
             store,
         }
     }
+
+    /// Size (in bytes) of this header in on-disk representation, not including padding
+    pub(crate) fn size(&self) -> u32 {
+        let index_size = self.index_header.num_entries * INDEX_ENTRY_SIZE;
+        let data_size = self.index_header.data_section_size;
+
+        INDEX_HEADER_SIZE + index_size + data_size
+    }
 }
 
 impl Header<IndexSignatureTag> {

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -2,6 +2,17 @@
 use crate::{constants::*, errors};
 use digest::Digest;
 
+/// Offsets into an RPM Package (from the start of the file) demarking locations of each section
+///
+/// See: `RPMPackage::get_package_component_offsets()`
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct RPMPackageSegmentOffsets {
+    pub lead: u64,
+    pub signature_header: u64,
+    pub header: u64,
+    pub payload: u64,
+}
+
 /// Describes a file present in the rpm file.
 pub struct RPMFileEntry {
     pub(crate) size: u32,

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -597,13 +597,13 @@ impl RPMPackageMetadata {
     /// ```
     /// # use rpm::RPMPackage;
     /// # let package = RPMPackage::open("test_assets/389-ds-base-devel-1.3.8.4-15.el7.x86_64.rpm").unwrap();
-    /// let (sig_header_start, header_start, payload_start) = package.metadata.get_package_segment_boundaries();
-    /// let lead = 0..sig_header_start;
-    /// let sig_header = sig_header_start..header_start;
-    /// let header = header_start..payload_start;
-    /// let payload = payload_start..;
+    /// let offsets = package.metadata.get_package_segment_offsets();
+    /// let lead = offsets.lead..offsets.signature_header;
+    /// let sig_header = offsets.signature_header..offsets.header;
+    /// let header = offsets.header..offsets.payload;
+    /// let payload = offsets.payload..;
     /// ```
-    pub fn get_package_segment_boundaries(&self) -> (u64, u64, u64) {
+    pub fn get_package_segment_offsets(&self) -> RPMPackageSegmentOffsets {
         // Lead is 96 bytes.
 
         // Each Header starts like this (16 bytes)
@@ -632,11 +632,12 @@ impl RPMPackageMetadata {
 
         let payload_start = header_start + header_size;
 
-        (
-            sig_header_start as u64,
-            header_start as u64,
-            payload_start as u64,
-        )
+        RPMPackageSegmentOffsets {
+            lead: 0,
+            signature_header: sig_header_start as u64,
+            header: header_start as u64,
+            payload: payload_start as u64,
+        }
     }
 
     #[inline]

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -311,7 +311,7 @@ pub struct RPMPackageMetadata {
 impl RPMPackageMetadata {
     #[cfg(feature = "async-futures")]
     pub async fn parse_async<T: AsyncRead + Unpin>(input: &mut T) -> Result<Self, RPMError> {
-        let mut lead_buffer = [0; LEAD_SIZE];
+        let mut lead_buffer = [0; LEAD_SIZE as usize];
         input.read_exact(&mut lead_buffer).await?;
         let lead = Lead::parse(&lead_buffer)?;
         let signature_header = Header::parse_signature_async(input).await?;
@@ -324,7 +324,7 @@ impl RPMPackageMetadata {
     }
 
     pub(crate) fn parse<T: std::io::BufRead>(input: &mut T) -> Result<Self, RPMError> {
-        let mut lead_buffer = [0; LEAD_SIZE];
+        let mut lead_buffer = [0; LEAD_SIZE as usize];
         input.read_exact(&mut lead_buffer)?;
         let lead = Lead::parse(&lead_buffer)?;
         let signature_header = Header::parse_signature(input)?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -196,7 +196,11 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
         assert_eq!(*tag, actual_entry.tag);
     }
 
-    assert_eq!("xz", metadata.get_payload_compressor()?);
+    assert_eq!(
+        metadata.get_package_segment_boundaries(),
+        (96, 1384, 148172)
+    );
+    assert_eq!(metadata.get_payload_compressor()?, "xz");
 
     let expected_file_checksums = vec![
         "",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -197,8 +197,13 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
     }
 
     assert_eq!(
-        metadata.get_package_segment_boundaries(),
-        (96, 1384, 148172)
+        metadata.get_package_segment_offsets(),
+        RPMPackageSegmentOffsets {
+            lead: 0,
+            signature_header: 96,
+            header: 1384,
+            payload: 148172
+        }
     );
     assert_eq!(metadata.get_payload_compressor()?, "xz");
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,7 +12,7 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
     let metadata = &package.metadata;
     assert_eq!(metadata.signature.index_entries.len(), 7);
     assert_eq!(metadata.signature.index_entries[0].num_items, 16);
-    assert_eq!(metadata.signature.index_header.header_size, 1156);
+    assert_eq!(metadata.signature.index_header.data_section_size, 1156);
 
     assert_eq!(package.metadata.get_name().unwrap(), "389-ds-base-devel");
     assert!(package.metadata.get_epoch().is_err());

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -18,8 +18,7 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
     fn assert_boundaries(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         let mut f = File::open(path)?;
         let package = RPMPackage::open(path)?;
-        let (sig_header_start, header_start, payload_start) =
-            package.metadata.get_package_segment_boundaries();
+        let offsets = package.metadata.get_package_segment_offsets();
 
         // Verify that we see an RPM magic #
         let mut buf = [0u8; 4];
@@ -28,30 +27,29 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(buf, RPM_MAGIC);
 
         // Seek to the start of the sig header and verify that we see a header magic #
-        f.seek(SeekFrom::Start(sig_header_start))?;
+        f.seek(SeekFrom::Start(offsets.signature_header))?;
         let mut buf = [0u8; 3];
         f.read_exact(&mut buf)?;
 
         assert_eq!(buf, HEADER_MAGIC);
 
         // Seek to the start of the header and verify that we see a header magic #
-        f.seek(SeekFrom::Start(header_start))?;
+        f.seek(SeekFrom::Start(offsets.header))?;
         let mut buf = [0u8; 3];
         f.read_exact(&mut buf)?;
 
         assert_eq!(buf, HEADER_MAGIC);
 
         // Seek to the start of the payload and verify that we see a magic # appropriate for the payload type
-        f.seek(SeekFrom::Start(payload_start))?;
+        f.seek(SeekFrom::Start(offsets.payload))?;
         let mut buf = [0u8; 10];
         f.read_exact(&mut buf)?;
 
-        let payload_magic: &[u8] = match package.metadata.get_payload_compressor().unwrap_or("none")
-        {
-            "gzip" => &[0x1f, 0x8b],
-            "zstd" => &[0x28, 0xb5, 0x2f, 0xfd],
-            "xz" => &[0xfd, 0x37, 0x7a, 0x58, 0x5a],
-            "none" => &[0x30, 0x37, 0x30, 0x37, 0x30, 0x31], // CPIO archive magic #
+        let payload_magic: &[u8] = match package.metadata.get_payload_compressor().ok() {
+            Some("gzip") => &[0x1f, 0x8b],
+            Some("zstd") => &[0x28, 0xb5, 0x2f, 0xfd],
+            Some("xz") => &[0xfd, 0x37, 0x7a, 0x58, 0x5a],
+            None => &[0x30, 0x37, 0x30, 0x37, 0x30, 0x31], // CPIO archive magic #
             a => unimplemented!("{:?}", a),
         };
 


### PR DESCRIPTION
The motivating reason is that RPM repo metadata has an element in the XML which declares the start and end boundaries of the header, so we need to expose some way to get that. 

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
