### PR TITLE
Make parsing more robust in the face of unknown or unexpected tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and decompression and has better ratios, and includes features which `libflate` does not
   such as configurable compression levels.
 
+### Fixed
+
+- Made parsing more robust in the face of unknown or unexpected tags. This will prevent new
+  packages from causing the program to crash if rpm-rs does not yet have a constant defined.
+  Also, RPMs in the wild are "messy" and it is sadly commonplace for tags to present in the
+  wrong header.
+
 ## 0.10.0
 
 ### Added

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,11 +25,6 @@ pub enum RPMError {
     },
     #[error("unsupported Version {0} - only header version 1 is supported")]
     UnsupportedHeaderVersion(u8),
-    #[error("invalid tag {raw_tag} for store {store_type}")]
-    InvalidTag {
-        raw_tag: u32,
-        store_type: &'static str,
-    },
     #[error("invalid tag data type in store {store_type}: expected 0 - 9 but got {raw_data_type}")]
     InvalidTagDataType {
         raw_data_type: u32,

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -657,7 +657,6 @@ pub(crate) struct IndexEntry<T: num::FromPrimitive> {
     pub(crate) data: IndexData,
     pub(crate) offset: i32,
     pub(crate) num_items: u32,
-
     // Marks what type of IndexEntry it is
     entry_type: PhantomData<T>,
 }
@@ -665,15 +664,15 @@ pub(crate) struct IndexEntry<T: num::FromPrimitive> {
 /// Custom Debug impl for the benefit of showing the tag name, if we are familiar with it
 impl<T: Tag> std::fmt::Debug for IndexEntry<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let tag = T::from_u32(self.tag);
-        let tag_val = if let Some(val) = tag {
+        let known_tag: Option<T> = num::FromPrimitive::from_u32(self.tag);
+        let tag_name = if let Some(val) = known_tag {
             format!("{:?}", val)
         } else {
             format!("UnknownTag[{:?}]", self.tag)
         };
 
         f.debug_struct(&format!("IndexEntry<{}>", T::tag_type_name()))
-            .field("tag", &tag_val)
+            .field("tag", &tag_name)
             .field("data", &self.data)
             .field("offset", &self.offset)
             .field("num_items", &self.num_items)
@@ -759,13 +758,14 @@ impl<T: Tag> IndexEntry<T> {
 
 impl<T: Tag> fmt::Display for IndexEntry<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let tag = T::from_u32(self.tag);
-        let tag_val = if let Some(val) = tag {
+        let known_tag: Option<T> = num::FromPrimitive::from_u32(self.tag);
+        let tag_name = if let Some(val) = known_tag {
             format!("{:?}", val)
         } else {
             format!("<< UnknownTag >> [{:?}]", self.tag)
         };
-        f.write_fmt(format_args!("{}: {}", tag_val, self.data))
+
+        f.write_fmt(format_args!("{}: {}", tag_name, self.data))
     }
 }
 

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -312,6 +312,44 @@ where
     }
 }
 
+impl fmt::Display for Header<IndexSignatureTag> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let summary = format!(
+            "Signature Header - Entries: {},  Data Section Size: {} bytes\n",
+            self.index_header.num_entries, self.index_header.data_section_size
+        );
+        f.write_str(&summary)?;
+        let separator = "=".repeat(summary.len());
+        f.write_str(&separator)?;
+        f.write_str("\n")?;
+
+        for entry in &self.index_entries {
+            f.write_fmt(format_args!("    {}\n", entry))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for Header<IndexTag> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let summary = format!(
+            "Header - Entries: {},  Data Section Size: {} bytes\n",
+            self.index_header.num_entries, self.index_header.data_section_size
+        );
+        f.write_str(&summary)?;
+        let separator = "=".repeat(summary.len());
+        f.write_str(&separator)?;
+        f.write_str("\n")?;
+
+        for entry in &self.index_entries {
+            f.write_fmt(format_args!("    {}\n", entry))?;
+        }
+
+        Ok(())
+    }
+}
+
 impl Header<IndexSignatureTag> {
     /// Create a new full signature header.
     ///
@@ -635,11 +673,11 @@ impl<T: Tag> std::fmt::Debug for IndexEntry<T> {
         };
 
         f.debug_struct(&format!("IndexEntry<{}>", T::tag_type_name()))
-         .field("tag", &tag_val)
-         .field("data", &self.data)
-         .field("offset", &self.offset)
-         .field("num_items", &self.num_items)
-         .finish()
+            .field("tag", &tag_val)
+            .field("data", &self.data)
+            .field("offset", &self.offset)
+            .field("num_items", &self.num_items)
+            .finish()
     }
 }
 
@@ -727,9 +765,7 @@ impl<T: Tag> fmt::Display for IndexEntry<T> {
         } else {
             format!("<< UnknownTag >> [{:?}]", self.tag)
         };
-        match &self.data {
-            _ => f.write_fmt(format_args!("{}: {}", tag_val, self.data)),
-        }
+        f.write_fmt(format_args!("{}: {}", tag_val, self.data))
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -196,7 +196,7 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
         let actual_entry = &metadata.signature.index_entries[i];
         assert_eq!(*len as u32, actual_entry.num_items);
         assert_eq!(*data, actual_entry.data);
-        assert_eq!(*tag, actual_entry.tag);
+        assert_eq!(*tag as u32, actual_entry.tag);
     }
 
     assert_eq!(


### PR DESCRIPTION
Unfortunately it is common for certain tags to be present in the wrong header, so there are many packages in the wild which rpm-rs would fail to parse. Additionally any packages built with brand-new versions of rpmbuild which contain tags not listed in our list of constants would fail.

In either case, we ought to be a bit more tolerant. Users should be able to parse the RPMs and do basic things with them even if we don't provide the ability to work with the unknown parts of the header.

This PR turns the `tag` into a standard u32 rather than an enum and removes the `InvalidTag` error variant.  It retains the other properties of `Header<T>` using the `PhantomData` zero-sized-type.  Additionally it adjusts the `Debug` trait impl to continue showing the tag names as before, rather than the raw integer value.

closes #119

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
