### PR TITLE
Delete async feature - this crate is not actually async-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
         flags:
           - "--all-features"
           - "--no-default-features"
-          - "--no-default-features --features signature-pgp,async-futures,with-file-async-async-std"
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -86,7 +85,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --features test-with-podman,with-file-async-tokio
+      - run: cargo test --features test-with-podman
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Also, RPMs in the wild are "messy" and it is sadly commonplace for tags to present in the
   wrong header.
 
+### Removed
+
+- Removed async support. This crate is poorly suited for use in an async runtime as IO is intermixed
+  with computationally expensive compression/decompression, digest and signature verification which
+  is likely to take on the order of seconds in some cases. This is "computational blocking". As an
+  alternative, if you need to perform actions with this crate within an async runtime, use the
+  `spawn_blocking` function on your executor of choice e.g.
+  <https://docs.rs/tokio/latest/tokio/index.html#cpu-bound-tasks-and-blocking-code>
+
 ## 0.10.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,6 @@ itertools = "0.10"
 hex = { version = "0.4", features = ["std"] }
 zstd = "0.12"
 xz2 = "0.1"
-futures = { version = "0.3.25", optional = true }
-
-# Libraries required for with_file_async() implementations
-async-std = { version = "1.12.0", optional = true }
-tokio = { version = "1", optional = true }
-tokio-util = { version = "0.7.4", features = ["compat"], optional = true }
 
 [dev-dependencies]
 rsa = { version = "0.8" }
@@ -67,20 +61,11 @@ serial_test = "2.0"
 pretty_assertions = "1.3.0"
 gethostname = "0.4"
 
-# Use for testing async files when async-futures enabled
-tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7.4", features = ["compat"] }
-
 [features]
 default = ["signature-pgp"]
 
 signature-pgp = ["signature-meta", "pgp"]
 signature-meta = []
-async-futures = ["futures"]
 
 # Segregate tests that require podman to be installed
 test-with-podman = ["signature-pgp"]
-# The use of these features implies that async-futures are being used -
-# explicitly define this feature.
-with-file-async-tokio = ["async-futures", "tokio/fs", "tokio-util"]
-with-file-async-async-std = ["async-futures", "async-std"]

--- a/src/rpm/headers/lead.rs
+++ b/src/rpm/headers/lead.rs
@@ -5,9 +5,6 @@ use std::convert::TryInto;
 use crate::constants::*;
 use crate::errors::*;
 
-#[cfg(feature = "async-futures")]
-use futures::io::{AsyncWrite, AsyncWriteExt};
-
 /// Lead of an rpm header.
 ///
 /// Used to contain valid data, now only a very limited subset is used
@@ -77,22 +74,6 @@ impl Lead {
             signature_type: sigtype,
             reserved: rest.try_into().unwrap(), // safe unwrap here since we've checked length of slices.
         })
-    }
-    #[cfg(feature = "async-futures")]
-    pub(crate) async fn write_async<W: AsyncWrite + Unpin>(
-        &self,
-        out: &mut W,
-    ) -> Result<(), RPMError> {
-        out.write_all(&self.magic).await?;
-        out.write_all(&self.major.to_be_bytes()).await?;
-        out.write_all(&self.minor.to_be_bytes()).await?;
-        out.write_all(&self.package_type.to_be_bytes()).await?;
-        out.write_all(&self.arch.to_be_bytes()).await?;
-        out.write_all(&self.name).await?;
-        out.write_all(&self.os.to_be_bytes()).await?;
-        out.write_all(&self.signature_type.to_be_bytes()).await?;
-        out.write_all(&self.reserved).await?;
-        Ok(())
     }
 
     pub(crate) fn write<W: std::io::Write>(&self, out: &mut W) -> Result<(), RPMError> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,7 +8,56 @@ fn cargo_manifest_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::Error>> {
+#[test]
+fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
+    use chrono::TimeZone;
+
+    let mut buff = std::io::Cursor::new(Vec::<u8>::new());
+
+    let pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
+        .compression(rpm::CompressionType::Gzip)
+        .with_file(
+            "Cargo.toml",
+            RPMFileOptions::new("/etc/awesome/config.toml").is_config(),
+        )?
+        // file mode is inherited from source file
+        .with_file("Cargo.toml", RPMFileOptions::new("/usr/bin/awesome"))?
+        .with_file(
+            "Cargo.toml",
+            // you can set a custom mode and custom user too
+            RPMFileOptions::new("/etc/awesome/second.toml")
+                .mode(0o100744)
+                .user("hugo"),
+        )?
+        .pre_install_script("echo preinst")
+        .add_changelog_entry(
+            "me",
+            "was awesome, eh?",
+            chrono::Utc.timestamp_opt(1681411811, 0).unwrap(),
+        )
+        .add_changelog_entry(
+            "you",
+            "yeah, it was",
+            chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00").unwrap(),
+        )
+        .requires(Dependency::any("wget"))
+        .vendor("dummy vendor")
+        .url("dummy url")
+        .vcs("dummy vcs")
+        .build()?;
+
+    pkg.write(&mut buff)?;
+
+    pkg.verify_digests()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_rpm_header() -> Result<(), Box<dyn std::error::Error>> {
+    let rpm_file_path = rpm_389_ds_file_path();
+    let package = RPMPackage::open(rpm_file_path)?;
+
     let metadata = &package.metadata;
     assert_eq!(metadata.signature.index_entries.len(), 7);
     assert_eq!(metadata.signature.index_entries[0].num_items, 16);
@@ -302,71 +351,4 @@ fn test_rpm_header_base(package: RPMPackage) -> Result<(), Box<dyn std::error::E
     package.verify_digests()?;
 
     Ok(())
-}
-
-#[cfg(feature = "async-futures")]
-#[tokio::test]
-async fn test_rpm_header_async() -> Result<(), Box<dyn std::error::Error>> {
-    use tokio_util::compat::TokioAsyncReadCompatExt;
-
-    let rpm_file_path = rpm_389_ds_file_path();
-    let mut rpm_file = tokio::fs::File::open(rpm_file_path).await?.compat();
-    let package = RPMPackage::parse_async(&mut rpm_file).await?;
-    test_rpm_header_base(package)
-}
-
-#[cfg(feature = "async-futures")]
-#[tokio::test]
-async fn test_rpm_builder_async() -> Result<(), Box<dyn std::error::Error>> {
-    use chrono::TimeZone;
-
-    let mut buff = std::io::Cursor::new(Vec::<u8>::new());
-
-    let pkg = RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
-        .compression(CompressionType::Gzip)
-        .with_file_async(
-            "Cargo.toml",
-            RPMFileOptions::new("/etc/awesome/config.toml").is_config(),
-        )
-        .await?
-        // file mode is inherited from source file
-        .with_file_async("Cargo.toml", RPMFileOptions::new("/usr/bin/awesome"))
-        .await?
-        .with_file_async(
-            "Cargo.toml",
-            // you can set a custom mode and custom user too
-            RPMFileOptions::new("/etc/awesome/second.toml")
-                .mode(0o100744)
-                .user("hugo"),
-        )
-        .await?
-        .pre_install_script("echo preinst")
-        .add_changelog_entry(
-            "me",
-            "was awesome, eh?",
-            chrono::Utc.timestamp_opt(1681411811, 0).unwrap(),
-        )
-        .add_changelog_entry(
-            "you",
-            "yeah, it was",
-            chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00").unwrap(),
-        )
-        .requires(Dependency::any("wget"))
-        .vendor("dummy vendor")
-        .url("dummy url")
-        .vcs("dummy vcs")
-        .build()?;
-
-    pkg.write(&mut buff)?;
-
-    pkg.verify_digests()?;
-
-    Ok(())
-}
-
-#[test]
-fn test_rpm_header() -> Result<(), Box<dyn std::error::Error>> {
-    let rpm_file_path = rpm_389_ds_file_path();
-    let package = RPMPackage::open(rpm_file_path)?;
-    test_rpm_header_base(package)
 }


### PR DESCRIPTION
I have had suspicions that this library may not be a good fit for async use, and have finally gotten around to checking whether they are accurate.

I wrote some executables to test

* building packages
* signing packages
* parsing packages
* verifying digests / signatures

Since async runtimes are all about latency and non-blocking cooperative multitasking, I tried to find the most realistic worst-case scenarios.  I wrote a script that printed a list of the top 20 largest packages in Fedora and downloaded a few of those (ranging from 100mb to 2.9gb).  I also tested normal sized packages like `zlib` and `sqlite` but while the magnitude was smaller the relative pattern was basically the same with those. For the "build" tests I extracted the contents of those packages and then used `rpm-rs` to recreate the packages using the pre-extracted files.

I used the `time` tool on my executables to print out how much time was spent waiting on IO (`sys` time) vs running computations (`user` time).  Everything was compiled in release mode, and I ran the executable directly (not through cargo) to avoid that overhead.  This was all using blocking IO for simplicity but it still tells us about the relevant information to judge async suitability.

To summarize my findings:

* Parsing the packages was pretty fast in *most* cases and was an ok-ish application of async, because 90% of the time was spent in IO.  *However:*
* If you then additionally verify the digests or signatures, then it flips the other way around and the workload becomes roughly 90% computation.  Computing all the digests was much more expensive than the IO was and the program would computationally block for *0.5 - 16 seconds*
* Signature verification was even more expensive, it would computationally block for *1 - 27 seconds*
* Building the packages, even using an scenario favorable to async by not using any compression (minimizing computation time and maximizing IO time), took 10-120 seconds and was nearly all computation.

Conclusion:

This is a huge footgun-in-waiting.   Most operations with `rpm-rs` are just too CPU-heavy to be run in an async runtime without the use of `spawn_blocking()` as described by the tokio documentation https://dtantsur.github.io/rust-openstack/tokio/index.html#cpu-bound-tasks-and-blocking-code.  Async isn't necessarily pointless in the parsing case, but as `spawn_blocking()` needs to be used for everything else anyway, we ought to just reduce complexity and be consistent about what we suggest users to do.

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
