### PR TITLE
Make RPMPackageMetadata::parse() and RPMPackageMetadata::open() public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default compression for building a package, if the compression is not overridden using
   the above method, is now `Gzip` rather than `None`. This is chosen to keep package
   sizes reasonable while maintaining maximum compatibility and minimizing computational cost.
+- Exposed `RPMPackageMetadata::parse()` and `RPMPackageMetadata::open()` so that it is
+  possible to read only package metadata without loading the payload into memory. This saves
+  time and memory over reading the entire file.
 
 ### Changed
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -301,7 +301,15 @@ impl RPMPackageMetadata {
         })
     }
 
-    pub(crate) fn parse<T: std::io::BufRead>(input: &mut T) -> Result<Self, RPMError> {
+    /// Open and parse RPMPackageMetadata from the file at the provided path
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, RPMError> {
+        let rpm_file = std::fs::File::open(path.as_ref())?;
+        let mut buf_reader = BufReader::new(rpm_file);
+        Self::parse(&mut buf_reader)
+    }
+
+    /// Parse RPMPackageMetadata from the provided reader
+    pub fn parse<T: std::io::BufRead>(input: &mut T) -> Result<Self, RPMError> {
         let mut lead_buffer = [0; LEAD_SIZE as usize];
         input.read_exact(&mut lead_buffer)?;
         let lead = Lead::parse(&lead_buffer)?;

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -77,8 +77,7 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_rpm_file_signatures() -> Result<(), Box<dyn std::error::Error>> {
     let rpm_file_path = common::rpm_ima_signed_file_path();
-    let package = RPMPackage::open(rpm_file_path)?;
-    let metadata = &package.metadata;
+    let metadata = RPMPackageMetadata::open(rpm_file_path)?;
 
     let signatures = metadata.get_file_ima_signatures()?;
 


### PR DESCRIPTION
If all you want is a quick way to read the package metadata, this works and saves time and memory.


### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
