### PR TITLE
Make get_payload_compressor() return CompressionType::None if the tag doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `CompressionType::None` is now returned instead of an error when calling `get_compression()` on
+  a package with an uncompressed payload.
+- Moved many constants to the bitflag-like types `DependencyFlags`, `FileVerifyFlags` and `FileFlags`
+- Changed the `FileEntry.category` field to `FileEntry.flags` and changed its type from an
+  enum to a bitflag-like type.
+- Renamed `FileDigestAlgorithm` to `DigestAlgorithm`, renamed `UnsupportedFileDigestAlgorithm`
+  to `UnsupportedDigestAlgorithm`
+
 ### Added
 
 - The compression level to be used during package building is now configurable by passing
@@ -18,24 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   possible to read only package metadata without loading the payload into memory. This saves
   time and memory over reading the entire file.
 
-### Changed
-
-- `flate2` crate is now used in place of `libflate`. `flate2` is faster in both compression
-  and decompression and has better ratios, and includes features which `libflate` does not
-  such as configurable compression levels.
-- Moved many constants to the bitflag-like types `DependencyFlags`, `FileVerifyFlags` and `FileFlags`
-- Changed the `FileEntry.category` field to `FileEntry.flags` and changed its type from an
-  enum to a bitflag-like type.
-- Renamed `FileDigestAlgorithm` to `DigestAlgorithm`, renamed `UnsupportedFileDigestAlgorithm`
-  to `UnsupportedDigestAlgorithm`
-
-### Fixed
-
-- Made parsing more robust in the face of unknown or unexpected tags. This will prevent new
-  packages from causing the program to crash if rpm-rs does not yet have a constant defined.
-  Also, RPMs in the wild are "messy" and it is sadly commonplace for tags to present in the
-  wrong header.
-
 ### Removed
 
 - Removed async support. This crate is poorly suited for use in an async runtime as IO is intermixed
@@ -44,6 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alternative, if you need to perform actions with this crate within an async runtime, use the
   `spawn_blocking` function on your executor of choice e.g.
   <https://docs.rs/tokio/latest/tokio/index.html#cpu-bound-tasks-and-blocking-code>
+
+### Changed
+
+- `flate2` crate is now used in place of `libflate`. `flate2` is faster in both compression
+  and decompression and has better ratios, and includes features which `libflate` does not
+  such as configurable compression levels.
+
+### Fixed
+
+- Made parsing more robust in the face of unknown or unexpected tags. This will prevent new
+  packages from causing the program to crash if rpm-rs does not yet have a constant defined.
+  Also, RPMs in the wild are "messy" and it is sadly commonplace for tags to present in the
+  wrong header.
 
 ## 0.10.0
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -626,10 +626,18 @@ impl RPMPackageMetadata {
 
     #[inline]
     pub fn get_payload_compressor(&self) -> Result<CompressionType, RPMError> {
-        let comp_str = self
-            .header
-            .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOADCOMPRESSOR)?;
-        CompressionType::from_str(comp_str)
+        self.header
+            .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOADCOMPRESSOR)
+            .map_or_else(
+                |e| {
+                    if matches!(e, RPMError::TagNotFound(_)) {
+                        Ok(CompressionType::None)
+                    } else {
+                        Err(e)
+                    }
+                },
+                CompressionType::from_str,
+            )
     }
 
     #[inline]

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -58,12 +58,11 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
         let mut buf = [0u8; 10];
         f.read_exact(&mut buf)?;
 
-        let payload_magic: &[u8] = match package.metadata.get_payload_compressor().ok() {
-            Some(CompressionType::Gzip) => &[0x1f, 0x8b],
-            Some(CompressionType::Zstd) => &[0x28, 0xb5, 0x2f, 0xfd],
-            Some(CompressionType::Xz) => &[0xfd, 0x37, 0x7a, 0x58, 0x5a],
-            None => &[0x30, 0x37, 0x30, 0x37, 0x30, 0x31], // CPIO archive magic #
-            a => unimplemented!("{:?}", a),
+        let payload_magic: &[u8] = match package.metadata.get_payload_compressor().unwrap() {
+            CompressionType::Gzip => &[0x1f, 0x8b],
+            CompressionType::Zstd => &[0x28, 0xb5, 0x2f, 0xfd],
+            CompressionType::Xz => &[0xfd, 0x37, 0x7a, 0x58, 0x5a],
+            CompressionType::None => &[0x30, 0x37, 0x30, 0x37, 0x30, 0x31], // CPIO archive magic #
         };
 
         assert!(buf.starts_with(payload_magic));


### PR DESCRIPTION
### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
