### PR TITLE
Removed last async method

### DIFF
--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -77,13 +77,6 @@ impl RPMPackage {
         self.write(&mut BufWriter::new(std::fs::File::create(path)?))
     }
 
-    #[cfg(feature = "async-futures")]
-    pub async fn write_async<W: AsyncWrite + Unpin>(&self, out: &mut W) -> Result<(), RPMError> {
-        self.metadata.write_async(out).await?;
-        out.write_all(&self.content).await?;
-        Ok(())
-    }
-
     /// Prepare both header and content digests as used by the `SignatureIndex`.
     pub(crate) fn create_sig_header_digests(
         header: &[u8],


### PR DESCRIPTION
### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled

In PR: https://github.com/rpm-rs/rpm/pull/138 forgot to delete one method `RPMPackage::write_async`. 