### PR TITLE
Update pgp to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ digest = "0.10"
 sha2 = "0.10"
 md-5 = "0.10"
 sha1 = "0.10"
-pgp = { version = "0.9", optional = true }
+pgp = { version = "0.10", optional = true }
 chrono = "0.4"
 log = "0.4"
 itertools = "0.10"

--- a/src/rpm/signature/pgp.rs
+++ b/src/rpm/signature/pgp.rs
@@ -46,8 +46,8 @@ impl traits::Signing<traits::algorithm::RSA> for Signer {
             created: Some(now),
             unhashed_subpackets: vec![],
             hashed_subpackets: vec![
-                Subpacket::SignatureCreationTime(now),
-                Subpacket::Issuer(self.secret_key.key_id()),
+                Subpacket::critical(SubpacketData::SignatureCreationTime(now)),
+                Subpacket::critical(SubpacketData::Issuer(self.secret_key.key_id())),
                 //::pgp::packet::Subpacket::SignersUserID("rpm"), TODO this would be a nice addition
             ],
         };
@@ -282,11 +282,19 @@ pub(crate) mod test {
 
         // stage 1: verify created signature is fine
         let signature = signing_key
-            .create_signature(passwd_fn, ::pgp::crypto::HashAlgorithm::SHA2_256, digest)
+            .create_signature(
+                passwd_fn,
+                ::pgp::crypto::hash::HashAlgorithm::SHA2_256,
+                digest,
+            )
             .expect("Failed to crate signature");
 
         verification_key
-            .verify_signature(::pgp::crypto::HashAlgorithm::SHA2_256, digest, &signature)
+            .verify_signature(
+                ::pgp::crypto::hash::HashAlgorithm::SHA2_256,
+                digest,
+                &signature,
+            )
             .expect("Failed to validate signature");
 
         // stage 2: check parsing success
@@ -300,8 +308,8 @@ pub(crate) mod test {
             [digest[0], digest[1]],
             signature,
             vec![
-                ::pgp::packet::Subpacket::SignatureCreationTime(now()),
-                ::pgp::packet::Subpacket::Issuer(signing_key.key_id()),
+                ::pgp::packet::Subpacket::critical(SubpacketData::SignatureCreationTime(now())),
+                ::pgp::packet::Subpacket::critical(SubpacketData::Issuer(signing_key.key_id())),
                 //::pgp::packet::Subpacket::SignersUserID("rpm"), TODO this would be a nice addition
             ],
             vec![],
@@ -319,7 +327,11 @@ pub(crate) mod test {
         assert_eq!(signature, wrapped);
         let signature = signature.signature;
         verification_key
-            .verify_signature(::pgp::crypto::HashAlgorithm::SHA2_256, digest, &signature)
+            .verify_signature(
+                ::pgp::crypto::hash::HashAlgorithm::SHA2_256,
+                digest,
+                &signature,
+            )
             .expect("Verify must succeed");
     }
 
@@ -343,8 +355,8 @@ pub(crate) mod test {
             created: Some(now),
             unhashed_subpackets: vec![],
             hashed_subpackets: vec![
-                Subpacket::SignatureCreationTime(now),
-                Subpacket::Issuer(signer.secret_key.key_id()),
+                Subpacket::critical(SubpacketData::SignatureCreationTime(now)),
+                Subpacket::critical(SubpacketData::Issuer(signer.secret_key.key_id())),
                 //::pgp::packet::Subpacket::SignersUserID("rpm"), TODO this would be a nice addition
             ],
         };


### PR DESCRIPTION
pgp v0.9 causes the following future incompatibility warning:
```
warning: the following packages contain code that will be rejected by a future version of Rust: buf_redux v0.8.4, nom v4.2.3
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```