### PR TITLE
Include build time by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Build time is now included into package by default.
+
 ### Fixed
 
 - CentOS 7 support by using long sizes only for packages bigger than 4 GiB

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 //!                         .user("hugo"),
 //!             )?
 //!             .pre_install_script("echo preinst")
-//!             .build_time(chrono::Utc::now())
 //!             .build_host(gethostname::gethostname().to_str().expect("Hostname works. qed").to_string())
 //!             .add_changelog_entry("Max Mustermann <max@example.com> - 0.1-29", "- was awesome, eh?", chrono::DateTime::parse_from_rfc2822("Wed, 19 Apr 2023 23:16:09 GMT").expect("Date 1 is correct. qed"))
 //!             .add_changelog_entry("Charlie Yom <test2@example.com> - 0.1-28", "- yeah, it was", chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00").expect("Date 2 is corrrect. qed"))


### PR DESCRIPTION
Closes #147.

In a future breaking release it's probably worth to change API of `build_time` to something similar to code in this [comment](https://github.com/rpm-rs/rpm/issues/147#issuecomment-1568653374).