### PR TITLE
Add source_date method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- `source_date` method for clamping modification time of files
+
 ## Changed
 
-- Build time is now included into package by default.
+- Build time is now included into package by default
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Build time is now included into package by default.
+
 ### Fixed
 
 - CentOS 7 support by using long sizes only for packages bigger than 4 GiB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- `source_date` method for clamping modification time of files
+- `RPMBuilder::source_date()` method for clamping modification time of files. This allows reproducible builds when included files are re-generated (having the same content but with different mtimes).
 
 ## Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 //!                         .user("hugo"),
 //!             )?
 //!             .pre_install_script("echo preinst")
-//!             .build_time(chrono::Utc::now())
 //!             .build_host(gethostname::gethostname().to_str().expect("Hostname works. qed").to_string())
 //!             .add_changelog_entry("Max Mustermann <max@example.com> - 0.1-29", "- was awesome, eh?", chrono::DateTime::parse_from_rfc2822("Wed, 19 Apr 2023 23:16:09 GMT").expect("Date 1 is correct. qed"))
 //!             .add_changelog_entry("Charlie Yom <test2@example.com> - 0.1-28", "- yeah, it was", chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00").expect("Date 2 is corrrect. qed"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //! # #[cfg(feature = "signature-pgp")]
 //! # {
 //! let raw_secret_key = std::fs::read("./test_assets/secret_key.asc")?;
+//! // Use date of last commit in your VCS for reproducible builds
+//! let source_date = chrono::Utc::now();
 //! let pkg = rpm::RPMBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
 //!             .compression(rpm::CompressionType::Gzip)
 //!             .with_file(
@@ -41,6 +43,10 @@
 //!                         .user("hugo"),
 //!             )?
 //!             .pre_install_script("echo preinst")
+//!             // You can remove the following two methods,
+//!             // if you don't need reproducible builds
+//!             .build_time(source_date)
+//!             .source_date(source_date)
 //!             .build_host(gethostname::gethostname().to_str().expect("Hostname works. qed").to_string())
 //!             .add_changelog_entry("Max Mustermann <max@example.com> - 0.1-29", "- was awesome, eh?", chrono::DateTime::parse_from_rfc2822("Wed, 19 Apr 2023 23:16:09 GMT").expect("Date 1 is correct. qed"))
 //!             .add_changelog_entry("Charlie Yom <test2@example.com> - 0.1-28", "- yeah, it was", chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00").expect("Date 2 is corrrect. qed"))


### PR DESCRIPTION
Depends on #152

Relevant issue: #117

In v0.12 it may be worth to remove the `build_time` method altogether and instead set build time to `source_date` if it was set.