### PR TITLE
Add RPMTAG_RPMVERSION tag to headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Breaking Change
 
-- The `RPMBuilder::build_time` method is removed. Package build time is now included by default and can be clamped using the `RPMBuilder::source_date` method.
+- The `RPMBuilder::build_time` method is removed. Package build time is now included by default
+  and can be clamped using the `RPMBuilder::source_date` method.
+- Several of the signer and verifier trait APIs were changed
 
 ## Added
 
 - `RPMBuilder::source_date` method for clamping modification time of files, build time of the package, and signature time. This functionality is required for reproducible generation of packages.
 - `RPMPackage::sign_with_timestamp` method.
-- Package build time is now included by default.
+- The "rpmversion" tag is now populated so that packages know which library (and version)
+  they were built with.
+
+### Changed
+
+- Build time metadata is now included in the built package by default
 
 ### Fixed
 

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -762,7 +762,11 @@ impl RPMBuilder {
                 offset,
                 IndexData::Int32(vec![self.epoch]),
             ),
-            // @todo: write RPMTAG_RPMVERSION?
+            IndexEntry::new(
+                IndexTag::RPMTAG_RPMVERSION,
+                offset,
+                IndexData::StringTag(format!("rpm-rs {}", env!("CARGO_PKG_VERSION"))),
+            ),
             // @todo: write RPMTAG_PLATFORM?
             IndexEntry::new(
                 IndexTag::RPMTAG_VERSION,

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -107,7 +107,7 @@ impl RPMPackage {
     }
 
     /// Create package signatures using an external key and provided timestamp.
-    /// Adds geenrated signatures to the signature header.
+    /// Adds generated signatures to the signature header.
     ///
     /// This method is usually used for reproducible builds, otherwise you should
     /// prefer using the [`sign`][RPMPackage::sign] method instead.
@@ -115,7 +115,7 @@ impl RPMPackage {
     /// # Examples
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut package = rpm::RPMPackage::open("test_assets/monkeysphere-0.37-1.el7.noarch.rpm")?;
+    /// let mut package = rpm::RPMPackage::open("test_assets/ima_signed.rpm")?;
     /// let raw_secret_key = std::fs::read("./test_assets/secret_key.asc")?;
     /// let signer = rpm::signature::pgp::Signer::load_from_asc_bytes(&raw_secret_key)?;
     /// // It's recommended to use timestamp of last commit in your VCS


### PR DESCRIPTION
Purpose: Allows you to debug which library, and which version of the library the package was built with