### PR TITLE
Add support for setting RPMTAG_FILECAPS header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for setting file capabilities via the RPMTAGS_FILECAPS header.
+- `PackageMetadata::get_file_entries` method can get capability headers for each file.
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for setting file capabilities via the RPMTAGS_FILECAPS header.
+
 ## 0.12.0
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ capctl = "0.2.3"
 [dev-dependencies]
 rsa = { version = "0.8" }
 rsa-der = { version = "^0.3.0" }
+# Pin time due to msrv
+time = "=0.3.23"
 env_logger = "0.10.0"
 serial_test = "2.0"
 pretty_assertions = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ itertools = "0.11"
 hex = { version = "0.4", features = ["std"] }
 zstd = "0.12"
 xz2 = "0.1"
+capctl = "0.2.3"
 
 [dev-dependencies]
 rsa = { version = "0.8" }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ let pkg = rpm::PackageBuilder::new("test", "1.0.0", "MIT", "x86_64", "some aweso
         // you can set a custom mode and custom user too
         rpm::FileOptions::new("/etc/awesome/second.toml")
             .mode(rpm::FileMode::regular(0o644))
+            .caps("cap_sys_admin,cap_net_admin=pe")
             .user("hugo"),
     )?
     .pre_install_script("echo preinst")

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ let pkg = rpm::PackageBuilder::new("test", "1.0.0", "MIT", "x86_64", "some aweso
         // you can set a custom mode and custom user too
         rpm::FileOptions::new("/etc/awesome/second.toml")
             .mode(rpm::FileMode::regular(0o644))
-            .caps("cap_sys_admin,cap_net_admin=pe")
+            .caps("cap_sys_admin,cap_net_admin=pe")?
             .user("hugo"),
     )?
     .pre_install_script("echo preinst")

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,9 @@ pub enum Error {
     #[error("invalid destination path {path} - {desc}")]
     InvalidDestinationPath { path: String, desc: &'static str },
 
+    #[error("invalid capabilities specified {caps}")]
+    InvalidCapabilities { caps: String },
+
     #[error("signature packet not found in what is supposed to be a signature")]
     NoSignatureFound,
 

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -898,11 +898,6 @@ impl PackageBuilder {
                     IndexData::Int16(file_modes),
                 ),
                 IndexEntry::new(
-                    IndexTag::RPMTAG_FILECAPS,
-                    offset,
-                    IndexData::StringArray(file_caps),
-                ),
-                IndexEntry::new(
                     IndexTag::RPMTAG_FILERDEVS,
                     offset,
                     IndexData::Int16(file_rdevs),
@@ -978,6 +973,13 @@ impl PackageBuilder {
                     IndexData::StringArray(self.directories.into_iter().collect()),
                 ),
             ]);
+            if file_caps.iter().any(|caps| !caps.is_empty()) {
+                actual_records.extend([IndexEntry::new(
+                    IndexTag::RPMTAG_FILECAPS,
+                    offset,
+                    IndexData::StringArray(file_caps),
+                )])
+            }
         }
 
         actual_records.extend([

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -980,7 +980,12 @@ impl PackageBuilder {
                 actual_records.extend([IndexEntry::new(
                     IndexTag::RPMTAG_FILECAPS,
                     offset,
-                    IndexData::StringArray(file_caps.iter().map(|f| f.unwrap().to_string()).collect::<Vec<String>>()),
+                    IndexData::StringArray(
+                        file_caps
+                            .iter()
+                            .map(|f| f.unwrap().to_string())
+                            .collect::<Vec<String>>(),
+                    ),
                 )])
             }
         }

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -983,7 +983,10 @@ impl PackageBuilder {
                     IndexData::StringArray(
                         file_caps
                             .iter()
-                            .map(|f| f.unwrap_or(capctl::FileCaps::empty()).to_string())
+                            .map(|f| match f {
+                                Some(caps) => caps.to_string(),
+                                None => "".to_string(),
+                            })
                             .collect::<Vec<String>>(),
                     ),
                 )])

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -273,8 +273,8 @@ impl PackageBuilder {
     ///     )?
     ///      .with_file(
     ///         "./awesome-config.toml",
-    ///         // you can set a custom mode and custom user too
-    ///         rpm::FileOptions::new("/etc/awesome/second.toml").mode(0o100744).user("hugo"),
+    ///         // you can set a custom mode, capabilities and custom user too
+    ///         rpm::FileOptions::new("/etc/awesome/second.toml").mode(0o100744).caps("cap_sys_admin=pe").user("hugo"),
     ///     )?
     ///     .build()?;
     /// # Ok(())
@@ -349,6 +349,7 @@ impl PackageBuilder {
             link: options.symlink,
             modified_at,
             dir: dir.clone(),
+            caps: options.caps,
             sha_checksum,
         };
 
@@ -574,6 +575,7 @@ impl PackageBuilder {
         let files_len = self.files.len();
         let mut file_sizes = Vec::with_capacity(files_len);
         let mut file_modes = Vec::with_capacity(files_len);
+        let mut file_caps = Vec::with_capacity(files_len);
         let mut file_rdevs = Vec::with_capacity(files_len);
         let mut file_mtimes = Vec::with_capacity(files_len);
         let mut file_hashes = Vec::with_capacity(files_len);
@@ -594,6 +596,7 @@ impl PackageBuilder {
             combined_file_sizes += entry.size;
             file_sizes.push(entry.size);
             file_modes.push(entry.mode.into());
+            file_caps.push(entry.caps.to_owned());
             // I really do not know the difference. It seems like file_rdevice is always 0 and file_device number always 1.
             // Who knows, who cares.
             file_rdevs.push(0);
@@ -893,6 +896,11 @@ impl PackageBuilder {
                     IndexTag::RPMTAG_FILEMODES,
                     offset,
                     IndexData::Int16(file_modes),
+                ),
+                IndexEntry::new(
+                    IndexTag::RPMTAG_FILECAPS,
+                    offset,
+                    IndexData::StringArray(file_caps),
                 ),
                 IndexEntry::new(
                     IndexTag::RPMTAG_FILERDEVS,

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -349,6 +349,9 @@ impl PackageBuilder {
             link: options.symlink,
             modified_at,
             dir: dir.clone(),
+            // Convert the caps to a string, so that we can store it in the header.
+            // We do this so that it's possible to verify that caps are correct when provided
+            // and then later check if any were set
             caps: options.caps,
             sha_checksum,
         };
@@ -973,11 +976,11 @@ impl PackageBuilder {
                     IndexData::StringArray(self.directories.into_iter().collect()),
                 ),
             ]);
-            if file_caps.iter().any(|caps| !caps.is_empty()) {
+            if file_caps.iter().any(|caps| caps.is_some()) {
                 actual_records.extend([IndexEntry::new(
                     IndexTag::RPMTAG_FILECAPS,
                     offset,
-                    IndexData::StringArray(file_caps),
+                    IndexData::StringArray(file_caps.iter().map(|f| f.unwrap().to_string()).collect::<Vec<String>>()),
                 )])
             }
         }

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -274,7 +274,7 @@ impl PackageBuilder {
     ///      .with_file(
     ///         "./awesome-config.toml",
     ///         // you can set a custom mode, capabilities and custom user too
-    ///         rpm::FileOptions::new("/etc/awesome/second.toml").mode(0o100744).caps("cap_sys_admin=pe").user("hugo"),
+    ///         rpm::FileOptions::new("/etc/awesome/second.toml").mode(0o100744).caps("cap_sys_admin=pe")?.user("hugo"),
     ///     )?
     ///     .build()?;
     /// # Ok(())
@@ -983,7 +983,7 @@ impl PackageBuilder {
                     IndexData::StringArray(
                         file_caps
                             .iter()
-                            .map(|f| f.unwrap().to_string())
+                            .map(|f| f.unwrap_or(capctl::FileCaps::empty()).to_string())
                             .collect::<Vec<String>>(),
                     ),
                 )])

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -431,7 +431,7 @@ pub struct FileEntry {
     // @todo SELinux context? how is that done?
     pub digest: Option<FileDigest>,
     /// Defines any capabilities on the file.
-    pub caps: String,
+    pub caps: Option<String>,
 }
 
 fn parse_entry_data_number<'a, T, E, F>(

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -430,6 +430,8 @@ pub struct FileEntry {
     pub flags: FileFlags,
     // @todo SELinux context? how is that done?
     pub digest: Option<FileDigest>,
+    /// Defines any capabilities on the file.
+    pub caps: String,
 }
 
 fn parse_entry_data_number<'a, T, E, F>(

--- a/src/rpm/headers/signature_builder.rs
+++ b/src/rpm/headers/signature_builder.rs
@@ -197,8 +197,8 @@ mod test {
 
         let sig_header_only = [0u8; 32];
 
-        let digest_header_sha1 = hex::encode(&[0u8; 64]);
-        let digest_header_sha256: String = hex::encode(&[0u8; 64]);
+        let digest_header_sha1 = hex::encode([0u8; 64]);
+        let digest_header_sha256: String = hex::encode([0u8; 64]);
 
         let digest_header_and_archive = [0u8; 64];
 

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -188,8 +188,6 @@ pub struct FileOptions {
     pub(crate) caps: Option<FileCaps>,
 }
 
-
-
 impl FileOptions {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(dest: impl Into<String>) -> FileOptionsBuilder {
@@ -239,7 +237,11 @@ impl FileOptionsBuilder {
         // verify capabilities
         self.inner.caps = match FileCaps::from_str(&caps.into()) {
             Ok(caps) => Some(caps),
-            Err(e) => return Err(errors::Error::InvalidCapabilities { caps: e.to_string() }),
+            Err(e) => {
+                return Err(errors::Error::InvalidCapabilities {
+                    caps: e.to_string(),
+                })
+            }
         };
         Ok(self)
     }

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -25,6 +25,7 @@ pub struct PackageFileEntry {
     pub group: String,
     pub base_name: String,
     pub dir: String,
+    pub caps: String,
     pub(crate) content: Vec<u8>,
 }
 
@@ -179,6 +180,7 @@ pub struct FileOptions {
     pub(crate) mode: FileMode,
     pub(crate) flag: FileFlags,
     pub(crate) inherit_permissions: bool,
+    pub(crate) caps: String,
 }
 
 impl FileOptions {
@@ -193,6 +195,7 @@ impl FileOptions {
                 mode: FileMode::regular(0o664),
                 flag: FileFlags::empty(),
                 inherit_permissions: true,
+                caps: "".to_string(),
             },
         }
     }
@@ -221,6 +224,11 @@ impl FileOptionsBuilder {
     pub fn mode(mut self, mode: impl Into<FileMode>) -> Self {
         self.inner.mode = mode.into();
         self.inner.inherit_permissions = false;
+        self
+    }
+
+    pub fn caps(mut self, caps: impl Into<String>) -> Self {
+        self.inner.caps = caps.into();
         self
     }
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -867,19 +867,19 @@ impl PackageMetadata {
                     mtimes,
                     sizes,
                     flags,
-                    caps,
                 ))
+                .enumerate()
                 .try_fold::<Vec<FileEntry>, _, Result<_, Error>>(
                     Vec::with_capacity(n),
-                    |mut acc, (path, user, group, mode, digest, mtime, size, flags, _cap)| {
+                    |mut acc, (idx, (path, user, group, mode, digest, mtime, size, flags))| {
                         let digest = if digest.is_empty() {
                             None
                         } else {
                             Some(FileDigest::load_from_str(algorithm, digest)?)
                         };
                         let cap = match caps {
-                            Some(ref caps) => caps.get(acc.len()).map(|x| x.to_owned()),
-                            None => None
+                            Some(ref caps) => caps.get(idx).map(|x| x.to_owned()),
+                            None => None,
                         };
                         acc.push(FileEntry {
                             path,

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -833,10 +833,10 @@ impl PackageMetadata {
             .header
             .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEFLAGS);
         // @todo
-        // let caps = self.get_entry_i32_array_data(IndexTag::RPMTAG_FILECAPS)?;
+        let caps = self.header.get_entry_data_as_string_array(IndexTag::RPMTAG_FILECAPS);
 
-        match (modes, users, groups, digests, mtimes, sizes, flags) {
-            (Ok(modes), Ok(users), Ok(groups), Ok(digests), Ok(mtimes), Ok(sizes), Ok(flags)) => {
+        match (modes, users, groups, digests, mtimes, sizes, flags, caps) {
+            (Ok(modes), Ok(users), Ok(groups), Ok(digests), Ok(mtimes), Ok(sizes), Ok(flags), Ok(caps)) => {
                 let paths = self.get_file_paths()?;
                 let n = paths.len();
 
@@ -849,10 +849,11 @@ impl PackageMetadata {
                     mtimes,
                     sizes,
                     flags,
+                    caps,
                 ))
                 .try_fold::<Vec<FileEntry>, _, Result<_, Error>>(
                     Vec::with_capacity(n),
-                    |mut acc, (path, user, group, mode, digest, mtime, size, flags)| {
+                    |mut acc, (path, user, group, mode, digest, mtime, size, flags, cap)| {
                         let digest = if digest.is_empty() {
                             None
                         } else {
@@ -869,6 +870,7 @@ impl PackageMetadata {
                             digest,
                             flags: FileFlags::from_bits_retain(flags),
                             size: size as usize,
+                            caps: cap.to_owned(),
                         });
                         Ok(acc)
                     },
@@ -883,8 +885,9 @@ impl PackageMetadata {
                 Err(Error::TagNotFound(_)),
                 Err(Error::TagNotFound(_)),
                 Err(Error::TagNotFound(_)),
+                Err(Error::TagNotFound(_)),
             ) => Ok(vec![]),
-            (modes, users, groups, digests, mtimes, sizes, flags) => {
+            (modes, users, groups, digests, mtimes, sizes, flags, caps) => {
                 modes?;
                 users?;
                 groups?;
@@ -892,6 +895,7 @@ impl PackageMetadata {
                 mtimes?;
                 sizes?;
                 flags?;
+                caps?;
                 unreachable!()
             }
         }

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -878,7 +878,7 @@ impl PackageMetadata {
                             Some(FileDigest::load_from_str(algorithm, digest)?)
                         };
                         let cap = match caps {
-                            Some(ref caps) => caps.get(idx).map(|x| x.to_owned()),
+                            Some(caps) => caps.get(idx).map(|x| x.to_owned()),
                             None => None,
                         };
                         acc.push(FileEntry {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,8 +55,6 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
             );
             assert_eq!(f.ownership.user, "hugo".to_string());
         } else if f.path.as_os_str() == "/etc/awesome/config.toml" {
-            // The "=" capability is equivalent to an empty capability set
-            // https://www.man7.org/linux/man-pages/man3/cap_from_text.3.html
             assert_eq!(f.caps, Some("".to_string()));
         } else if f.path.as_os_str() == "/usr/bin/awesome" {
             assert_eq!(f.mode, FileMode::from(0o100644));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -51,11 +51,13 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
         if f.path.as_os_str() == "/etc/awesome/second.toml" {
             assert_eq!(
                 f.clone().caps.unwrap(),
-                "cap_sys_admin,cap_sys_ptrace=pe".to_string()
+                "cap_sys_ptrace,cap_sys_admin=ep".to_string()
             );
             assert_eq!(f.ownership.user, "hugo".to_string());
         } else if f.path.as_os_str() == "/etc/awesome/config.toml" {
-            assert_eq!(f.caps, Some("".to_string()));
+            // The "=" capability is equivalent to an empty capability set
+            // https://www.man7.org/linux/man-pages/man3/cap_from_text.3.html
+            assert_eq!(f.caps, Some("=".to_string()));
         } else if f.path.as_os_str() == "/usr/bin/awesome" {
             assert_eq!(f.mode, FileMode::from(0o100644));
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -57,7 +57,7 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
         } else if f.path.as_os_str() == "/etc/awesome/config.toml" {
             // The "=" capability is equivalent to an empty capability set
             // https://www.man7.org/linux/man-pages/man3/cap_from_text.3.html
-            assert_eq!(f.caps, Some("=".to_string()));
+            assert_eq!(f.caps, Some("".to_string()));
         } else if f.path.as_os_str() == "/usr/bin/awesome" {
             assert_eq!(f.mode, FileMode::from(0o100644));
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,7 +26,7 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
             // you can set a custom mode and custom user too
             FileOptions::new("/etc/awesome/second.toml")
                 .mode(0o100744)
-                .caps("cap_sys_admin,cap_sys_ptrace=pe")
+                .caps("cap_sys_admin,cap_sys_ptrace=pe")?
                 .user("hugo"),
         )?
         .pre_install_script("echo preinst")

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,6 +26,7 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
             // you can set a custom mode and custom user too
             FileOptions::new("/etc/awesome/second.toml")
                 .mode(0o100744)
+                .caps("cap_sys_admin,cap_sys_ptrace=pe")
                 .user("hugo"),
         )?
         .pre_install_script("echo preinst")

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -53,7 +53,7 @@ fn parse_externally_signed_rpm_and_verify() -> Result<(), Box<dyn std::error::Er
 /// Test an attempt to verify the signature of a package that is not signed
 #[test]
 fn test_verify_unsigned_package() -> Result<(), Box<dyn std::error::Error>> {
-    let pkg = rpm::Package::open(&common::rpm_empty_path())?;
+    let pkg = rpm::Package::open(common::rpm_empty_path())?;
 
     // test RSA
     let verification_key = common::rsa_public_key();
@@ -161,7 +161,7 @@ fn build_parse_sign_and_verify(
     assert_eq!(3, pkg.metadata.get_epoch()?);
 
     // sign
-    let signer: Signer = Signer::load_from_asc_bytes(signing_key.as_ref())?;
+    let signer: Signer = Signer::load_from_asc_bytes(signing_key)?;
     pkg.sign(signer)?;
 
     let out_file = common::cargo_out_dir().join(pkg_out_path.as_ref());
@@ -169,7 +169,7 @@ fn build_parse_sign_and_verify(
 
     // verify
     let package = rpm::Package::open(&out_file)?;
-    let verifier = Verifier::load_from_asc_bytes(verification_key.as_ref())?;
+    let verifier = Verifier::load_from_asc_bytes(verification_key)?;
     package.verify_signature(verifier)?;
 
     Ok(())


### PR DESCRIPTION
This change adds support for setting the RPMTAG_FILECAPS header to add capabilities to the files packaged in the rpm. 

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
