### PR TITLE
add symbolic link file type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Support for symbolic link in file mode.
+- Make file type const `REGULAR_FILE_TYPE` `DIR_FILE_TYPE` `SYMBOLIC_LINK_FILE_TYPE` public, because `FileMode::file_type` is public, sometimes we need this const to determin file type.
 ### Added
 - Support for setting file capabilities via the RPMTAGS_FILECAPS header.
 - `PackageMetadata::get_file_entries` method can get capability headers for each file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support for symbolic link in file mode.
-- Make file type const `REGULAR_FILE_TYPE` `DIR_FILE_TYPE` `SYMBOLIC_LINK_FILE_TYPE` public, because `FileMode::file_type` is public, sometimes we need this const to determin file type.
-### Added
 - Support for setting file capabilities via the RPMTAGS_FILECAPS header.
 - `PackageMetadata::get_file_entries` method can get capability headers for each file.
+- Support for symbolic link in file mode.
+- Make file type const `REGULAR_FILE_TYPE` `DIR_FILE_TYPE` `SYMBOLIC_LINK_FILE_TYPE` public, because `FileMode::file_type` is public, sometimes we need this const to determin file type.
 
 ## 0.12.0
 

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -138,9 +138,9 @@ impl FileMode {
     /// Returns the complete file mode (type and permissions)
     pub fn raw_mode(&self) -> u16 {
         match self {
-            Self::Dir { permissions } | Self::Regular { permissions } | Self::SymbolicLink { permissions } => {
-                *permissions | self.file_type()
-            }
+            Self::Dir { permissions }
+            | Self::Regular { permissions }
+            | Self::SymbolicLink { permissions } => *permissions | self.file_type(),
             Self::Invalid {
                 raw_mode,
                 reason: _,
@@ -162,7 +162,9 @@ impl FileMode {
 
     pub fn permissions(&self) -> u16 {
         match self {
-            Self::Dir { permissions } | Self::Regular { permissions } | Self::SymbolicLink { permissions } => *permissions,
+            Self::Dir { permissions }
+            | Self::Regular { permissions }
+            | Self::SymbolicLink { permissions } => *permissions,
             Self::Invalid {
                 raw_mode,
                 reason: _,
@@ -452,8 +454,16 @@ mod test {
             (0o10_0755, FileMode::regular(0o0755), REGULAR_FILE_TYPE),
             (0o10_1755, FileMode::regular(0o1755), REGULAR_FILE_TYPE),
             (0o04_0755, FileMode::dir(0o0755), DIR_FILE_TYPE),
-            (0o12_0755, FileMode::symbolic_link(0o0755), SYMBOLIC_LINK_FILE_TYPE),
-            (0o12_1755, FileMode::symbolic_link(0o1755), SYMBOLIC_LINK_FILE_TYPE),
+            (
+                0o12_0755,
+                FileMode::symbolic_link(0o0755),
+                SYMBOLIC_LINK_FILE_TYPE,
+            ),
+            (
+                0o12_1755,
+                FileMode::symbolic_link(0o1755),
+                SYMBOLIC_LINK_FILE_TYPE,
+            ),
             (
                 0o20_0755,
                 FileMode::Invalid {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -29,6 +29,12 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
                 .caps("cap_sys_admin,cap_sys_ptrace=pe")?
                 .user("hugo"),
         )?
+        .with_file(
+            "./test_assets/empty_file_for_symlink_create",
+            FileOptions::new("/usr/bin/awesome_link")
+                .mode(0o120644)
+                .symlink("/usr/bin/awesome"),
+        )?
         .pre_install_script("echo preinst")
         .add_changelog_entry("me", "was awesome, eh?", 1_681_411_811)
         .add_changelog_entry("you", "yeah, it was", 850_984_797)
@@ -57,7 +63,9 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
         } else if f.path.as_os_str() == "/etc/awesome/config.toml" {
             assert_eq!(f.caps, Some("".to_string()));
         } else if f.path.as_os_str() == "/usr/bin/awesome" {
-            assert_eq!(f.mode, FileMode::from(0o100644));
+            assert_eq!(f.mode, FileMode::from(0o100777));
+        } else if f.path.as_os_str() == "/usr/bin/awesome_link" {
+            assert_eq!(f.mode, FileMode::from(0o120644));
         }
     });
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,7 +63,7 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
         } else if f.path.as_os_str() == "/etc/awesome/config.toml" {
             assert_eq!(f.caps, Some("".to_string()));
         } else if f.path.as_os_str() == "/usr/bin/awesome" {
-            assert_eq!(f.mode, FileMode::from(0o100777));
+            assert_eq!(f.mode, FileMode::from(0o100644));
         } else if f.path.as_os_str() == "/usr/bin/awesome_link" {
             assert_eq!(f.mode, FileMode::from(0o120644));
         }

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -68,6 +68,12 @@ mod pgp {
                 cargo_file.to_str().unwrap(),
                 FileOptions::new("/etc/Cargo.toml"),
             )?
+            .with_file(
+                "./test_assets/empty_file_for_symlink_create",
+                FileOptions::new("/usr/bin/awesome_link")
+                    .mode(0o120644)
+                    .symlink("/usr/bin/awesome"),
+            )?
             .epoch(1)
             .pre_install_script("echo preinst")
             .add_changelog_entry(


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->
### PR Content Desc

- Sometimes not standard rpm package container symbolic link, it is better to recognize them.
- `FileMode::file_type` is public, so it is better to make the const `REGULAR_FILE_TYPE` `DIR_FILE_TYPE` `SYMBOLIC_LINK_FILE_TYPE` public also to ease usage.

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
