### PR TITLE
Fix compile error on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of a `description`. A new method `PackageBuilder::description` can be used to
   set a detailed description for a package; if not set, the description defaults
   to the `summary`.
+- Fix compile error on Windows which introduced by file capabilities support feature.
 
 ## 0.12.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ itertools = "0.11"
 hex = { version = "0.4", features = ["std"] }
 zstd = "0.12"
 xz2 = "0.1"
+[target.'cfg(unix)'.dependencies]
 capctl = "0.2.3"
 
 [dev-dependencies]

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -356,6 +356,7 @@ impl PackageBuilder {
             link: options.symlink,
             modified_at,
             dir: dir.clone(),
+            #[cfg(unix)]
             // Convert the caps to a string, so that we can store it in the header.
             // We do this so that it's possible to verify that caps are correct when provided
             // and then later check if any were set
@@ -585,6 +586,7 @@ impl PackageBuilder {
         let files_len = self.files.len();
         let mut file_sizes = Vec::with_capacity(files_len);
         let mut file_modes = Vec::with_capacity(files_len);
+        #[cfg(unix)]
         let mut file_caps = Vec::with_capacity(files_len);
         let mut file_rdevs = Vec::with_capacity(files_len);
         let mut file_mtimes = Vec::with_capacity(files_len);
@@ -606,6 +608,7 @@ impl PackageBuilder {
             combined_file_sizes += entry.size;
             file_sizes.push(entry.size);
             file_modes.push(entry.mode.into());
+            #[cfg(unix)]
             file_caps.push(entry.caps.to_owned());
             // I really do not know the difference. It seems like file_rdevice is always 0 and file_device number always 1.
             // Who knows, who cares.
@@ -983,6 +986,7 @@ impl PackageBuilder {
                     IndexData::StringArray(self.directories.into_iter().collect()),
                 ),
             ]);
+            #[cfg(unix)]
             if file_caps.iter().any(|caps| caps.is_some()) {
                 actual_records.extend([IndexEntry::new(
                     IndexTag::RPMTAG_FILECAPS,

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -1,7 +1,9 @@
 //! A collection of types used in various header records.
+#[cfg(unix)]
 use std::str::FromStr;
 
 use crate::{constants::*, errors, Timestamp};
+#[cfg(unix)]
 use capctl::FileCaps;
 use digest::Digest;
 
@@ -28,6 +30,7 @@ pub struct PackageFileEntry {
     pub group: String,
     pub base_name: String,
     pub dir: String,
+    #[cfg(unix)]
     pub caps: Option<FileCaps>,
     pub(crate) content: Vec<u8>,
 }
@@ -198,6 +201,7 @@ pub struct FileOptions {
     pub(crate) mode: FileMode,
     pub(crate) flag: FileFlags,
     pub(crate) inherit_permissions: bool,
+    #[cfg(unix)]
     pub(crate) caps: Option<FileCaps>,
 }
 
@@ -213,6 +217,7 @@ impl FileOptions {
                 mode: FileMode::regular(0o664),
                 flag: FileFlags::empty(),
                 inherit_permissions: true,
+                #[cfg(unix)]
                 caps: None,
             },
         }
@@ -246,6 +251,7 @@ impl FileOptionsBuilder {
         self
     }
 
+    #[cfg(unix)]
     pub fn caps(mut self, caps: impl Into<String>) -> Result<Self, errors::Error> {
         // verify capabilities
         self.inner.caps = match FileCaps::from_str(&caps.into()) {
@@ -490,12 +496,14 @@ mod test {
         Ok(())
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_verify_capabilities_valid() {
         let blank_file = crate::FileOptions::new("/usr/bin/awesome");
         blank_file.caps("cap_net_admin,cap_net_raw+p").unwrap();
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_verify_capabilities_invalid() -> Result<(), crate::errors::Error> {
         let blank_file = crate::FileOptions::new("/usr/bin/awesome");


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

### PR Content Desc
- Compile on Windows will fail because of file capabilities feature introduced, even thought rpm is specific for Linux, but there are may be some cross platform tools build on top of this lib(such as my developing tools for rpm package info read and display)

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
