### PR TITLE
PackageBuilder: both summary and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for symbolic link in file mode.
 - Make file type const `REGULAR_FILE_TYPE` `DIR_FILE_TYPE` `SYMBOLIC_LINK_FILE_TYPE` public, because `FileMode::file_type` is public, sometimes we need this const to determin file type.
+- Method `PackageBuilder::new` now takes a `summary` as last parameter, instead
+  of a `description`. A new method `PackageBuilder::description` can be used to
+  set a detailed description for a package; if not set, the description defaults
+  to the `summary`.
 
 ## 0.12.1
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,6 +14,11 @@ fn test_rpm_builder() -> Result<(), Box<dyn std::error::Error>> {
     let mut buff = std::io::Cursor::new(Vec::<u8>::new());
 
     let pkg = PackageBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
+        .description(
+            "This is an awesome package.
+
+However, it does nothing.",
+        )
         .compression(rpm::CompressionType::Gzip)
         .with_file(
             "Cargo.toml",


### PR DESCRIPTION
Currently, when building a package with `PackageBuilder`, the same string `desc` is used for both `Summary` and `Description`:

https://github.com/rpm-rs/rpm/blob/bb5c1ea3b598ebd3e03969508057ab9e1d7ab359/src/rpm/builder.rs#L794-L802

However:
- `Summary` is meant to be a _"brief, one-line summary of the package"_ (rpmlint requires a short string which does not end with a dot).
- `Description` should be a  _"full description of the software packaged in the RPM. This description can span multiple lines and can be broken into paragraphs."_ And rpmlint requires a string which does end with a dot.

In this PR, I rename the last parameter of `PackageBuilder::new()` from `desc` to `summary`, and I add a setter `description` to the package builder.

The default value for `Description` is the summary, if no description has been set. That way, this is not really a breaking change. (the default value for the description could have be the summary followed by a dot, to comply with rpmlint recommended style, but this would have a be breaking change, for a small benefit).

I kept the summary mandatory and set the description optional, because all examples in the library used for `desc` a short description which fits more the role of a summary.

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
