### PR TITLE
Add method to check existence of payload separated digest for package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for setting file capabilities via the RPMTAGS_FILECAPS header.
 - `PackageMetadata::get_file_entries` method can get capability headers for each file.
+- Support check existence of package payload separated digest via `PackageMetadata::is_payload_separate_digest_present`
 
 ## 0.12.0
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -726,6 +726,15 @@ impl PackageMetadata {
             .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
     }
 
+    /// Whether payload separate digest present, or not
+    #[inline]
+    pub fn is_payload_separate_digest_present(&self) -> bool {
+        self.header.entry_is_present(IndexTag::RPMTAG_PAYLOADDIGEST)
+            || self
+                .header
+                .entry_is_present(IndexTag::RPMTAG_PAYLOADDIGESTALT)
+    }
+
     /// Extract a the set of contained file names.
     pub fn get_file_paths(&self) -> Result<Vec<PathBuf>, Error> {
         // reconstruct the messy de-constructed paths


### PR DESCRIPTION
Add the ability to check payload seperated digest for package metadata. see [rpm](https://github.com/rpm-software-management/rpm/blob/master/sign/rpmgensig.c#L601)

<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled
