### PR TITLE
Pin jobserver to prevent MSRV change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,8 @@ serial_test = "2.0"
 pretty_assertions = "1.3.0"
 gethostname = "0.4"
 hex-literal = "0.4"
+# Pin jobserver due to msrv
+jobserver = "=0.1.26"
 
 [features]
 default = ["signature-pgp"]


### PR DESCRIPTION
With the release of its version 1.0.27, crate `jobserver` increased its MSRV to 1.66, even if was set in Cargo.toml only a few days after the release

Cf. https://github.com/rust-lang/jobserver-rs/commit/9416b43378d79e4c6062030b1a1c66691ee01ee3

Without this dependency pinning, CI now fails (cf job https://github.com/rpm-rs/rpm/actions/runs/6531090162/job/17731629328 on PR #181 - the failure is unrelated to the PR)

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [ ] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled
