### PR TITLE
Add %config(noreplace) file attribute to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the `summary`.
 - Add method `with_key_passphrase` to `signature::pgp::Signer`, to provide the
   passphrase when the PGP secret key is passphrase-protected.
+- Add method `is_no_replace` to `FileOptionsBuilder`, used to set the
+  `%config(noreplace)` flag on a file.
 
 ## 0.12.1
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ let pkg = rpm::PackageBuilder::new("test", "1.0.0", "MIT", "x86_64", "some aweso
     .compression(rpm::CompressionType::Gzip)
     .with_file(
         "./test_assets/awesome.toml",
-        rpm::FileOptions::new("/etc/awesome/config.toml").is_config(),
+        rpm::FileOptions::new("/etc/awesome/config.toml")
+            .is_config()
+            .is_no_replace(),
     )?
     // file mode is inherited from source file
     .with_file(

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -260,27 +260,32 @@ impl FileOptionsBuilder {
     }
 
     pub fn is_doc(mut self) -> Self {
-        self.inner.flag = FileFlags::DOC;
+        self.inner.flag.insert(FileFlags::DOC);
         self
     }
 
     pub fn is_config(mut self) -> Self {
-        self.inner.flag = FileFlags::CONFIG;
+        self.inner.flag.insert(FileFlags::CONFIG);
+        self
+    }
+
+    pub fn is_no_replace(mut self) -> Self {
+        self.inner.flag.insert(FileFlags::NOREPLACE);
         self
     }
 
     pub fn is_ghost(mut self) -> Self {
-        self.inner.flag = FileFlags::GHOST;
+        self.inner.flag.insert(FileFlags::GHOST);
         self
     }
 
     pub fn is_license(mut self) -> Self {
-        self.inner.flag = FileFlags::LICENSE;
+        self.inner.flag.insert(FileFlags::LICENSE);
         self
     }
 
     pub fn is_readme(mut self) -> Self {
-        self.inner.flag = FileFlags::README;
+        self.inner.flag.insert(FileFlags::README);
         self
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -22,7 +22,9 @@ However, it does nothing.",
         .compression(rpm::CompressionType::Gzip)
         .with_file(
             "Cargo.toml",
-            FileOptions::new("/etc/awesome/config.toml").is_config(),
+            FileOptions::new("/etc/awesome/config.toml")
+                .is_config()
+                .is_no_replace(),
         )?
         // file mode is inherited from source file
         .with_file("Cargo.toml", FileOptions::new("/usr/bin/awesome"))?
@@ -67,6 +69,7 @@ However, it does nothing.",
             assert_eq!(f.ownership.user, "hugo".to_string());
         } else if f.path.as_os_str() == "/etc/awesome/config.toml" {
             assert_eq!(f.caps, Some("".to_string()));
+            assert_eq!(f.flags, FileFlags::CONFIG | FileFlags::NOREPLACE);
         } else if f.path.as_os_str() == "/usr/bin/awesome" {
             assert_eq!(f.mode, FileMode::from(0o100644));
         } else if f.path.as_os_str() == "/usr/bin/awesome_link" {

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -50,7 +50,8 @@ mod pgp {
                 cargo_file.to_str().unwrap(),
                 FileOptions::new("/etc/foobar/hugo/bazz.toml")
                     .mode(0o100_777)
-                    .is_config(),
+                    .is_config()
+                    .is_no_replace(),
             )?
             .with_file(
                 cargo_file.to_str().unwrap(),


### PR DESCRIPTION
Add method `is_no_replace` to `FileOptionsBuilder`, used to set the `%config(noreplace)` flag on a file

Closes #186 

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
