### PR TITLE
Unify file-related information under FileEntry (get_file_entries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add method `is_no_replace` to `FileOptionsBuilder`, used to set the
   `%config(noreplace)` flag on a file.
 - Added the `FileEntry.linkto` field that is a target of a symbolic link.
+- Removed `get_file_checksums`, `get_file_ima_signatures` and `get_file_digest_algorithm`
+  function and the information is accessible via `FileEntry` struct
+  (`FileEntry::digest_string` and `FileEntry::ima_signature`).
+- Function `get_file_entries` returned empty vector for an RPM file without any file.
 
 ## 0.12.1
 

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -430,10 +430,13 @@ pub struct FileEntry {
     pub flags: FileFlags,
     // @todo SELinux context? how is that done?
     pub digest: Option<FileDigest>,
+    pub digest_string: String,
     /// Defines any capabilities on the file.
     pub caps: Option<String>,
     /// Defines a target of a symlink (if the file is a symbolic link).
     pub linkto: String,
+    /// Integrity Measurement Architecture (IMA) signature.
+    pub ima_signature: Option<String>,
 }
 
 fn parse_entry_data_number<'a, T, E, F>(

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -80,14 +80,18 @@ fn test_rpm_file_signatures() -> Result<(), Box<dyn std::error::Error>> {
     let rpm_file_path = common::rpm_ima_signed_file_path();
     let metadata = rpm::PackageMetadata::open(rpm_file_path)?;
 
-    let signatures = metadata.get_file_ima_signatures()?;
+    let signatures: Vec<_> = metadata
+        .get_file_entries()?
+        .iter()
+        .map(|f| f.ima_signature.clone())
+        .collect();
 
     assert_eq!(
         signatures,
         [
-            "0302041adfaa0e004630440220162785458f5d81d1393cc72afc642c86167c15891ea39213e28907b1c4e8dc6c02202fa86ad2f5e474d36c59300f736f52cb5ed24abb55759a71ec224184a7035a78",
-            "0302041adfaa0e00483046022100bd940093777b75650980afb656507f2729a05c9b1bc9986993106de9f301a172022100b3384f6ba200a5a80647a0f0727c5b8f3ab01f74996a1550db605b44af3d10bf",
-            "0302041adfaa0e00473045022068953626d7a5b65aa4b1f1e79a2223f2d3500ddcb3d75a7050477db0480a13e10221008637cefe8c570044e11ff95fa933c1454fd6aa8793bbf3e87edab2a2624df460",
+            Some(String::from("0302041adfaa0e004630440220162785458f5d81d1393cc72afc642c86167c15891ea39213e28907b1c4e8dc6c02202fa86ad2f5e474d36c59300f736f52cb5ed24abb55759a71ec224184a7035a78")),
+            Some(String::from("0302041adfaa0e00483046022100bd940093777b75650980afb656507f2729a05c9b1bc9986993106de9f301a172022100b3384f6ba200a5a80647a0f0727c5b8f3ab01f74996a1550db605b44af3d10bf")),
+            Some(String::from("0302041adfaa0e00473045022068953626d7a5b65aa4b1f1e79a2223f2d3500ddcb3d75a7050477db0480a13e10221008637cefe8c570044e11ff95fa933c1454fd6aa8793bbf3e87edab2a2624df460")),
         ],
     );
 


### PR DESCRIPTION
Support all file-related functions for a case where an RPM is free of files.