### PR TITLE
add` PackageBuilder::with_files` too allows batch addition of files to a rpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of a `description`. A new method `PackageBuilder::description` can be used to
   set a detailed description for a package; if not set, the description defaults
   to the `summary`.
+- Add method `PackageBuilder::with_files` to allow addition of multiple files to rpm at one shot
 - Add method `with_key_passphrase` to `signature::pgp::Signer`, to provide the
   passphrase when the PGP secret key is passphrase-protected.
 - Add method `is_no_replace` to `FileOptionsBuilder`, used to set the

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -306,6 +306,30 @@ impl PackageBuilder {
         Ok(self)
     }
 
+    /// Add multiple file to the package.
+    ///
+    /// ```
+    /// # fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let files =vec![(
+    ///         "./awesome-config.toml",
+    ///         rpm::FileOptions::new("/etc/awesome/config.toml").is_config(),
+    ///     ),    ///     // file mode is inherited from source file
+    ///     (
+    ///         "./awesome-bin",
+    ///         rpm::FileOptions::new("/usr/bin/awesome"),
+    ///     ),
+    ///     (
+    ///         "./awesome-config.toml",
+    ///         // you can set a custom mode, capabilities and custom user too
+    ///         rpm::FileOptions::new("/etc/awesome/second.toml").mode(0o100744).caps("cap_sys_admin=pe")?.user("hugo"),
+    ///     )];
+    /// let pkg = rpm::PackageBuilder::new("foo", "1.0.0", "Apache-2.0", "x86_64", "some baz package")
+    ///     .with_files(files)?
+    ///     .build()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+
     pub fn with_files(
         mut self,
         files: Vec<(impl AsRef<Path>, impl Into<FileOptions>)>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -84,7 +84,76 @@ However, it does nothing.",
             assert_eq!(f.mode, FileMode::from(0o120644));
         }
     });
+    Ok(())
+}
 
+#[test]
+fn test_rpm_batch_builder() -> Result<(), Box<dyn std::error::Error>> {
+    let mut buff = std::io::Cursor::new(Vec::<u8>::new());
+    let files = vec![
+        (
+            "Cargo.toml",
+            FileOptions::new("/etc/awesome/config.toml")
+                .is_config()
+                .is_no_replace(),
+        ),
+        ("Cargo.toml", FileOptions::new("/usr/bin/awesome")),
+        (
+            "Cargo.toml",
+            // you can set a custom mode and custom user too
+            FileOptions::new("/etc/awesome/second.toml")
+                .mode(0o100744)
+                .caps("cap_sys_admin,cap_sys_ptrace=pe")?
+                .user("hugo"),
+        ),
+        (
+            "./test_assets/empty_file_for_symlink_create",
+            FileOptions::new("/usr/bin/awesome_link")
+                .mode(0o120644)
+                .symlink("/usr/bin/awesome"),
+        ),
+    ];
+    let pkg = PackageBuilder::new("test", "1.0.0", "MIT", "x86_64", "some awesome package")
+        .description(
+            "This is an awesome package. that was built in a batch.
+
+However, it does nothing.",
+        )
+        .compression(rpm::CompressionType::Gzip)
+        .with_files(files)?
+        .pre_install_script("echo preinst")
+        .add_changelog_entry("me", "was awesome, eh?", 1_681_411_811)
+        .add_changelog_entry("you", "yeah, it was", 850_984_797)
+        .requires(Dependency::any("wget"))
+        .vendor("dummy vendor")
+        .url("dummy url")
+        .vcs("dummy vcs")
+        .build()?;
+    pkg.write(&mut buff)?;
+
+    // check that generated packages has source rpm tag
+    // to be more compatibly recognized as RPM binary packages
+    pkg.metadata.get_source_rpm()?;
+
+    pkg.verify_digests()?;
+
+    // check various metadata on the files
+    pkg.metadata.get_file_entries()?.iter().for_each(|f| {
+        if f.path.as_os_str() == "/etc/awesome/second.toml" {
+            assert_eq!(
+                f.clone().caps.unwrap(),
+                "cap_sys_ptrace,cap_sys_admin=ep".to_string()
+            );
+            assert_eq!(f.ownership.user, "hugo".to_string());
+        } else if f.path.as_os_str() == "/etc/awesome/config.toml" {
+            assert_eq!(f.caps, Some("".to_string()));
+            assert_eq!(f.flags, FileFlags::CONFIG | FileFlags::NOREPLACE);
+        } else if f.path.as_os_str() == "/usr/bin/awesome" {
+            assert_eq!(f.mode, FileMode::from(0o100644));
+        } else if f.path.as_os_str() == "/usr/bin/awesome_link" {
+            assert_eq!(f.mode, FileMode::from(0o120644));
+        }
+    });
     Ok(())
 }
 


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

This pr address #193 and adds a `with_files` method which allows adding multiple files in batches to the rpm. There is a test based of `with_file` and documentation as well.

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
