### PR TITLE
Make Error Send + Sync (fixes #191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Error` now implements `Send + Sync`.
+- `Error` now implements `Send + Sync` (therefore, `Result<Package, Error>` now implements `Send + Sync`).
 
 ## 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `Error` now implements `Send + Sync`.
+
 ## 0.13.0
 
 ### Breaking Changes

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,6 +56,7 @@ pub enum Error {
     #[error("signature packet not found in what is supposed to be a signature")]
     NoSignatureFound,
 
+    #[cfg(feature = "signature-pgp")]
     #[error("error creating signature: {0}")]
     SignError(#[source] pgp::errors::Error),
 
@@ -66,6 +67,7 @@ pub enum Error {
         Utf8Error,
     ),
 
+    #[cfg(feature = "signature-pgp")]
     #[error("errors parsing keys, failed to parse bytes as ascii armored key")]
     KeyLoadSecretKeyError(
         #[from]
@@ -73,6 +75,7 @@ pub enum Error {
         pgp::errors::Error,
     ),
 
+    #[cfg(feature = "signature-pgp")]
     #[error("error verifying signature with key {key_ref}: {source}")]
     VerificationError {
         #[source]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -123,6 +123,7 @@ impl From<TimestampError> for Error {
     }
 }
 
+// Assert at compile-time that Error implements Send and Sync.
 const _: () = {
     const fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<Error>();


### PR DESCRIPTION
Uses a different approach than the ones in comments of #191. Most errors do not need to be boxed, and introducing two error variants instead of having one very generic one (with static details) ends up not being too bad.

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled
