### PR TITLE
Expose PackageMetadata::write publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved documentation
+- `PackageMetadata::write` is now public
 
 ### Fixed
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -375,7 +375,8 @@ impl PackageMetadata {
         })
     }
 
-    pub(crate) fn write(&self, out: &mut impl io::Write) -> Result<(), Error> {
+    /// Write the RPM header to a buffer
+    pub fn write(&self, out: &mut impl io::Write) -> Result<(), Error> {
         self.lead.write(out)?;
         self.signature.write_signature(out)?;
         self.header.write(out)?;


### PR DESCRIPTION
Closes #216

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
