### PR TITLE
Use almalinux 8 instead of CentOS Stream 8 for tests

### DIFF
--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -25,7 +25,7 @@ mod pgp {
             ("fedora:40", &rpm_sig_check),
             ("fedora:40", &dnf_cmd),
             ("centos:stream9", &dnf_cmd),
-            ("centos:stream8", &dnf_cmd),
+            ("almalinux:8", &dnf_cmd),
         ]
         .iter()
         .try_for_each(|(image, cmd)| {


### PR DESCRIPTION
CentOS Stream 8 is EOL now, the repos are taken down.