### PR TITLE
Speed up parse_header of the binary IndexData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The `Header::parse_header` function gained a speed up related to parsing of the binary headers.
+
 ## 0.15.0
 
 ### Breaking Changes


### PR DESCRIPTION
The change makes a measurable performance gain for debuginfod-rs:

```
Before:
  Time (mean ± σ):      2.322 s ±  0.042 s    [User: 25.047 s, System: 4.994 s]
After:
  Time (mean ± σ):      2.269 s ±  0.023 s    [User: 24.264 s, System: 5.174 s]

1.02 ± 0.02 times faster than debuginfod-rs-before
```