### PR TITLE
Fix clippy warning:

### DIFF
--- a/src/rpm/filecaps.rs
+++ b/src/rpm/filecaps.rs
@@ -117,7 +117,7 @@ pub fn validate_caps_text(s: &str) -> Result<(), Error> {
     }
 
     for part in s.split_whitespace() {
-        let index = match part.find(|c| c == '+' || c == '-' || c == '=') {
+        let index = match part.find(['+', '-', '=']) {
             Some(i) => i,
             None => return Err(Error::InvalidFileCaps("`+/-/=` not found".to_owned())),
         };


### PR DESCRIPTION
```
warning: this manual char comparison can be written more succinctly
   --> src/rpm/filecaps.rs:120:37
    |
120 |         let index = match part.find(|c| c == '+' || c == '-' || c == '=') {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['+', '-', '=']`
```