### PR TITLE
Remove extra allocation in get_file_paths

### DIFF
--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -770,7 +770,7 @@ impl PackageMetadata {
                         |mut acc, item| {
                             let (basename, dir_index) = item;
                             if let Some(dir) = dirs.get(dir_index as usize) {
-                                acc.push(PathBuf::from(dir).join(basename));
+                                acc.push(Path::new(dir).join(basename));
                                 Ok(acc)
                             } else {
                                 Err(Error::InvalidTagIndex {


### PR DESCRIPTION
I was able to measure a difference for debuginfod-rs:

```
  Time (mean ± σ):      2.303 s ±  0.017 s    [User: 25.220 s, System: 5.214 s]
  Range (min … max):    2.272 s …  2.327 s    10 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: /tmp/after3
  Time (mean ± σ):      2.298 s ±  0.028 s    [User: 24.979 s, System: 5.310 s]
  Range (min … max):    2.241 s …  2.331 s    10 runs

  Warning: Ignoring non-zero exit code.

Summary
  /tmp/after3
    1.00 ± 0.01 times faster than /tmp/before
```