### PR TITLE
Add feature flag for multithreaded zstd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The `Header::parse_header` function gained a speed up related to parsing of the binary headers.
+- Added `zstdmt` feature which sets zstd compression to use all available cores.
 
 ## 0.15.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,5 @@ signature-meta = []
 
 # Segregate tests that require podman to be installed
 test-with-podman = ["signature-pgp"]
+
+zstdmt = ["zstd/zstdmt"]


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

This commit adds an optional feature flag which enable zstd compression on all threads of the CPU.
