### PR TITLE
Add feature flags for compression algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `zstdmt` feature which sets zstd compression to use all available cores.
 - Added feature flags for every compression algorithm to support disabling unused ones.
 
+### Breaking Changes
+
+- Changed default compression scheme from Gzip to Zstd.
+
 ## 0.15.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `Header::parse_header` function gained a speed up related to parsing of the binary headers.
 - Added `zstdmt` feature which sets zstd compression to use all available cores.
+- Added feature flags for every compression algorithm to support disabling unused ones.
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - Changed default compression scheme from Gzip to Zstd.
+- Removed bzip2 from the compression options enabled by default.
 
 ## 0.15.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ num = "0.4"
 enum-primitive-derive = "0.3"
 enum-display-derive = "0.1"
 cpio = "0.4"
-flate2 = "1"
+flate2 = { version = "1", optional = true }
 digest = "0.10"
 sha2 = "0.10"
 md-5 = "0.10"
@@ -51,9 +51,9 @@ chrono = { version = "0.4", optional = true }
 log = "0.4"
 itertools = "0.13"
 hex = { version = "0.4", features = ["std"] }
-zstd = "0.13"
-xz2 = "0.1"
-bzip2 = "0.4.4"
+zstd = { version = "0.13", optional = true }
+xz2 = { version = "0.1", optional = true }
+bzip2 = { version = "0.4.4", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"
@@ -63,7 +63,18 @@ gethostname = "0.5"
 hex-literal = "0.4"
 
 [features]
-default = ["signature-pgp"]
+default = [
+    "signature-pgp",
+    "gzip-compression",
+    "zstd-compression",
+    "xz-compression",
+    "bzip2-compression"
+]
+
+gzip-compression = ["flate2"]
+zstd-compression = ["zstd"]
+xz-compression = ["xz2"]
+bzip2-compression = ["bzip2"]
 
 signature-pgp = ["signature-meta", "pgp", "chrono"]
 signature-meta = []
@@ -71,4 +82,4 @@ signature-meta = []
 # Segregate tests that require podman to be installed
 test-with-podman = ["signature-pgp"]
 
-zstdmt = ["zstd/zstdmt"]
+zstdmt = ["zstd-compression", "zstd/zstdmt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ default = [
     "gzip-compression",
     "zstd-compression",
     "xz-compression",
-    "bzip2-compression"
 ]
 
 gzip-compression = ["flate2"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -94,6 +94,9 @@ pub enum Error {
     #[error("unknown compressor type {0} - supported types: gzip, zstd, xz, bzip2 and none")]
     UnknownCompressorType(String),
 
+    #[error("unsupported compressor type {0} - try enabling the feature flag for it")]
+    UnsupportedCompressorType(String),
+
     #[error("unsupported digest algorithm {0:?}")]
     UnsupportedDigestAlgorithm(DigestAlgorithm),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 //! A library providing API to parse rpms as well as
 //! creating rpms from individual files.
 //!
-//! All supported compression types are behind feature flags which are enabled by default. They can
-//! be disable if these compression algorithms are unused.
+//! All supported compression types are behind feature flags. All of them except bzip2 are enabled
+//! by default. They can be disable if these compression algorithms are unused.
 //!
 //! # Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 //! A library providing API to parse rpms as well as
 //! creating rpms from individual files.
 //!
+//! All supported compression types are behind feature flags which are enabled by default. They can
+//! be disable if these compression algorithms are unused.
+//!
 //! # Example
 //!
 //! ```

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -22,6 +22,7 @@ use crate::signature;
 
 use crate::Package;
 use crate::PackageMetadata;
+
 use crate::{CompressionType, CompressionWithLevel};
 
 #[cfg(unix)]

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -28,11 +28,15 @@ impl std::str::FromStr for CompressionType {
 
 pub enum Compressor {
     None(Vec<u8>),
+    #[cfg(feature = "gzip-compression")]
     Gzip(flate2::write::GzEncoder<Vec<u8>>),
     /// If the `zstdmt` feature flag is enabled, compression will use all available cores to
     /// compress the file.
+    #[cfg(feature = "zstd-compression")]
     Zstd(zstd::stream::Encoder<'static, Vec<u8>>),
+    #[cfg(feature = "xz-compression")]
     Xz(xz2::write::XzEncoder<Vec<u8>>),
+    #[cfg(feature = "bzip2-compression")]
     Bzip2(bzip2::write::BzEncoder<Vec<u8>>),
 }
 
@@ -42,9 +46,11 @@ impl TryFrom<CompressionWithLevel> for Compressor {
     fn try_from(value: CompressionWithLevel) -> Result<Self, Self::Error> {
         match value {
             CompressionWithLevel::None => Ok(Compressor::None(Vec::new())),
+            #[cfg(feature = "gzip-compression")]
             CompressionWithLevel::Gzip(level) => Ok(Compressor::Gzip(
                 flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::new(level)),
             )),
+            #[cfg(feature = "zstd-compression")]
             CompressionWithLevel::Zstd(level) => {
                 #[cfg_attr(not(feature = "zstdmt"), allow(unused_mut))]
                 let mut stream = zstd::stream::Encoder::new(Vec::new(), level)?;
@@ -58,13 +64,18 @@ impl TryFrom<CompressionWithLevel> for Compressor {
 
                 Ok(Compressor::Zstd(stream))
             }
+            #[cfg(feature = "xz-compression")]
             CompressionWithLevel::Xz(level) => Ok(Compressor::Xz(xz2::write::XzEncoder::new(
                 Vec::new(),
                 level,
             ))),
+            #[cfg(feature = "bzip2-compression")]
             CompressionWithLevel::Bzip2(level) => Ok(Compressor::Bzip2(
                 bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::new(level)),
             )),
+            // This is an issue when building with all compression types enabled
+            #[allow(unreachable_patterns)]
+            _ => Err(Error::UnsupportedCompressorType(value.to_string())),
         }
     }
 }
@@ -73,18 +84,26 @@ impl Write for Compressor {
     fn write(&mut self, content: &[u8]) -> Result<usize, std::io::Error> {
         match self {
             Compressor::None(data) => data.write(content),
+            #[cfg(feature = "gzip-compression")]
             Compressor::Gzip(encoder) => encoder.write(content),
+            #[cfg(feature = "zstd-compression")]
             Compressor::Zstd(encoder) => encoder.write(content),
+            #[cfg(feature = "xz-compression")]
             Compressor::Xz(encoder) => encoder.write(content),
+            #[cfg(feature = "bzip2-compression")]
             Compressor::Bzip2(encoder) => encoder.write(content),
         }
     }
     fn flush(&mut self) -> Result<(), std::io::Error> {
         match self {
             Compressor::None(data) => data.flush(),
+            #[cfg(feature = "gzip-compression")]
             Compressor::Gzip(encoder) => encoder.flush(),
+            #[cfg(feature = "zstd-compression")]
             Compressor::Zstd(encoder) => encoder.flush(),
+            #[cfg(feature = "xz-compression")]
             Compressor::Xz(encoder) => encoder.flush(),
+            #[cfg(feature = "bzip2-compression")]
             Compressor::Bzip2(encoder) => encoder.flush(),
         }
     }
@@ -94,9 +113,13 @@ impl Compressor {
     pub(crate) fn finish_compression(self) -> Result<Vec<u8>, Error> {
         match self {
             Compressor::None(data) => Ok(data),
+            #[cfg(feature = "gzip-compression")]
             Compressor::Gzip(encoder) => Ok(encoder.finish()?),
+            #[cfg(feature = "zstd-compression")]
             Compressor::Zstd(encoder) => Ok(encoder.finish()?),
+            #[cfg(feature = "xz-compression")]
             Compressor::Xz(encoder) => Ok(encoder.finish()?),
+            #[cfg(feature = "bzip2-compression")]
             Compressor::Bzip2(encoder) => Ok(encoder.finish()?),
         }
     }
@@ -126,8 +149,26 @@ impl CompressionWithLevel {
 }
 
 impl Default for CompressionWithLevel {
+    // The preference of the default compression type is listed in decending order and dependent on
+    // the enabled feature flags.
+    // Writing this without allowing unreachable code is possible but not very pretty. It involves
+    // checking if the previous features haven't been enabled on each return so this is a
+    // reasonable tradeoff.
+    #[allow(unreachable_code)]
     fn default() -> Self {
-        CompressionType::Gzip.into()
+        #[cfg(feature = "gzip-compression")]
+        return CompressionType::Gzip.into();
+
+        #[cfg(feature = "zstd-compression")]
+        return CompressionType::Zstd.into();
+
+        #[cfg(feature = "xz-compression")]
+        return CompressionType::Xz.into();
+
+        #[cfg(feature = "bzip2-compression")]
+        return CompressionType::Bzip2.into();
+
+        CompressionType::None.into()
     }
 }
 
@@ -139,6 +180,18 @@ impl From<CompressionType> for CompressionWithLevel {
             CompressionType::Xz => CompressionWithLevel::Xz(9),
             CompressionType::Zstd => CompressionWithLevel::Zstd(19),
             CompressionType::Bzip2 => CompressionWithLevel::Bzip2(9),
+        }
+    }
+}
+
+impl std::fmt::Display for CompressionWithLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Gzip(level) => write!(f, "gzip, compression level {level}"),
+            Self::Zstd(level) => write!(f, "zstd, compression level {level}"),
+            Self::Xz(level) => write!(f, "xz, compression level {level}"),
+            Self::Bzip2(level) => write!(f, "bzip2, compression level {level}"),
         }
     }
 }

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -165,9 +165,6 @@ impl Default for CompressionWithLevel {
         #[cfg(feature = "xz-compression")]
         return CompressionType::Xz.into();
 
-        #[cfg(feature = "bzip2-compression")]
-        return CompressionType::Bzip2.into();
-
         CompressionType::None.into()
     }
 }

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -156,11 +156,11 @@ impl Default for CompressionWithLevel {
     // reasonable tradeoff.
     #[allow(unreachable_code)]
     fn default() -> Self {
-        #[cfg(feature = "gzip-compression")]
-        return CompressionType::Gzip.into();
-
         #[cfg(feature = "zstd-compression")]
         return CompressionType::Zstd.into();
+
+        #[cfg(feature = "gzip-compression")]
+        return CompressionType::Gzip.into();
 
         #[cfg(feature = "xz-compression")]
         return CompressionType::Xz.into();


### PR DESCRIPTION
This pull request adds a feature flag for every compression algorithm. All compression algorithms are all enabled by default, but can be disabled in case they are not used to reduce the amount of dependencies.

Please note: I couldn't run all the tests because some containers are not found in the registry I am using.