### PR TITLE
tests: centos on docker hub went EOL

### DIFF
--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -22,8 +22,8 @@ mod pgp {
         let rpm_sig_check = format!("rpm -vv --checksig {} 2>&1;", path.as_ref().display());
         // TODO: check signatures on all distros?
         [
-            ("fedora:40", &rpm_sig_check),
-            ("fedora:40", &dnf_cmd),
+            ("quay.io/fedora/fedora:40", &rpm_sig_check),
+            ("quay.io/fedora/fedora:40", &dnf_cmd),
             ("quay.io/centos/centos:stream9", &dnf_cmd),
             ("almalinux:8", &dnf_cmd),
         ]

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -24,7 +24,7 @@ mod pgp {
         [
             ("fedora:40", &rpm_sig_check),
             ("fedora:40", &dnf_cmd),
-            ("centos:stream9", &dnf_cmd),
+            ("quay.io/centos/centos:stream9", &dnf_cmd),
             ("almalinux:8", &dnf_cmd),
         ]
         .iter()


### PR DESCRIPTION
centos docker image went EOL in June 2024 and do not appear to be available on hub.docker.com anymore.

This breaks tests when you don't already have an image cached on your computer.

This commit migrates to one available on quay.io

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
