### PR TITLE
Add Issuer as regular packet during signing.

### DIFF
--- a/src/rpm/signature/pgp.rs
+++ b/src/rpm/signature/pgp.rs
@@ -66,6 +66,11 @@ where
             .push(Subpacket::regular(SubpacketData::Issuer(
                 self.secret_key.key_id(),
             )));
+        sig_cfg
+            .hashed_subpackets
+            .push(Subpacket::regular(SubpacketData::IssuerFingerprint(
+                self.secret_key.fingerprint(),
+            )));
         //::pgp::packet::Subpacket::SignersUserID("rpm"), TODO this would be a nice addition
 
         let passwd_fn = || self.key_passphrase.clone().unwrap_or_default();

--- a/src/rpm/signature/pgp.rs
+++ b/src/rpm/signature/pgp.rs
@@ -60,10 +60,10 @@ where
         );
         sig_cfg
             .hashed_subpackets
-            .push(Subpacket::critical(SubpacketData::SignatureCreationTime(t)));
+            .push(Subpacket::regular(SubpacketData::SignatureCreationTime(t)));
         sig_cfg
             .hashed_subpackets
-            .push(Subpacket::critical(SubpacketData::Issuer(
+            .push(Subpacket::regular(SubpacketData::Issuer(
                 self.secret_key.key_id(),
             )));
         //::pgp::packet::Subpacket::SignersUserID("rpm"), TODO this would be a nice addition

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -25,9 +25,13 @@ mod pgp {
         let rpm_sig_check = format!("rpm -vv --checksig {} 2>&1;", path.as_ref().display());
         // TODO: check signatures on all distros?
         [
-            ("quay.io/fedora/fedora:40", &rpm_sig_check),
-            ("quay.io/fedora/fedora:40", &dnf_cmd),
+            ("quay.io/fedora/fedora:41", &rpm_sig_check),
+            ("quay.io/fedora/fedora:41", &dnf_cmd),
+            ("quay.io/centos/centos:stream9", &rpm_sig_check),
             ("quay.io/centos/centos:stream9", &dnf_cmd),
+            ("quay.io/centos/centos:centos8", &rpm_sig_check),
+            ("quay.io/centos/centos:centos8", &dnf_cmd),
+            ("almalinux:8", &rpm_sig_check),
             ("almalinux:8", &dnf_cmd),
         ]
         .iter()


### PR DESCRIPTION
RPM in RHEL 8 and 9 are unable to find the signing key id when signed with this the rpm crate.  Newer versions of RPM do not have this issue.

By adding a second Issuer packet which is not critical works around the old RPM deficiency.

Closes #265
<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
