### PR TITLE
Add methods to calculate metadata size

### DIFF
--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -284,7 +284,7 @@ where
     }
 
     /// Size (in bytes) of this header in on-disk representation, not including padding
-    pub(crate) fn size(&self) -> u32 {
+    pub fn size(&self) -> u32 {
         let index_size = self.index_header.num_entries * INDEX_ENTRY_SIZE;
         let data_size = self.index_header.data_section_size;
 
@@ -352,7 +352,7 @@ impl Header<IndexSignatureTag> {
     ///
     /// Parsing and writing out this section requires knowing how much padding is needed to complete
     /// the alignment.
-    pub(crate) fn padding_required(&self) -> u32 {
+    pub fn padding_required(&self) -> u32 {
         (8 - (self.index_header.data_section_size % 8)) % 8
     }
 
@@ -381,6 +381,12 @@ impl Header<IndexSignatureTag> {
             out.write_all(&padding)?;
         }
         Ok(())
+    }
+
+    /// Calculate the padded size for the this signature header.
+    /// This is the actual size this header will take on disk.
+    pub fn padded_size(&self) -> u32 {
+        self.size() + self.padding_required()
     }
 }
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -9,7 +9,12 @@ use std::{
 use digest::Digest;
 use num_traits::FromPrimitive;
 
-use crate::{CompressionType, constants::*, decompress_stream, errors::*};
+use crate::{
+    CompressionType,
+    constants::{self, *},
+    decompress_stream,
+    errors::*,
+};
 
 #[cfg(feature = "signature-pgp")]
 use crate::signature::pgp::Verifier;
@@ -490,6 +495,11 @@ impl PackageMetadata {
             signature: signature_header,
             header,
         })
+    }
+
+    /// Calculate the complete size of the metadata block, including lead, signature, padding and header size.
+    pub fn get_total_metadata_size(&self) -> u32 {
+        self.header.size() + self.signature.padded_size() + constants::LEAD_SIZE
     }
 
     /// Write the RPM header to a buffer

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -451,3 +451,26 @@ fn test_no_rpm_files() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn test_metadata_size() -> Result<(), Box<dyn std::error::Error>> {
+    // these numbers are calculated with the help of createrepo.
+    // here is how to reproduce if necessary:
+    // copy all listed RPM's in a directory, run "createrepo --update ." in this directory
+    // inspect the resulting primary.xml file and search for package > format > rpm:header-range.
+    // the field "end" contains the value you are looking for.
+    let test_table = [
+        ("389-ds-base-devel-1.3.8.4-15.el7.x86_64.rpm", 148172),
+        ("freesrp-udev-0.3.0-1.25.x86_64.rpm", 7989),
+        ("ima_signed.rpm", 6520),
+        ("rpm-sign-4.15.1-1.fc31.x86_64.rpm", 17328),
+    ];
+
+    for (pkg_name, expected) in test_table {
+        let path = cargo_manifest_dir().join("test_assets").join(pkg_name);
+        let pkg = Package::open(path)?;
+        assert_eq!(expected, pkg.metadata.get_total_metadata_size())
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
DNF repositories represent the binary RPM metadata in XML. Some metadata that is stored is related to sizes, e.G: `<rpm:header-range start="4504" end="17328"/>`
The given example metadata effectively says "Header starts at 4504 and ends at 17328"
This patch implements the necessary methods to calculate these sizes:
```rust
let end = pkg.metadata.get_total_metadata_size();
let start = end - pkg.metadata.header.size();
```

<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

### 📜 Checklist

- [ ] Commits are cleanly separated and have useful messages
- [ ] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled
