### PR TITLE
chore(deps): update pgp requirement from 0.17 to 0.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.85.0
+          - 1.88.0
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -58,7 +58,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.85.0
+          - 1.88.0
         flags:
           - "--all-features"
           - "--no-default-features"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking Changes
+
+- Bump MSRV to 1.88
+
+### Changed
+
+- Bump `pgp` to `0.18.0`
+
 ## 0.18.4
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/rpm-rs/rpm"
 readme = "README.md"
 keywords = ["RPM", "packaging"]
 categories = ["parsing", "development-tools"]
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 
 [lib]
 name = "rpm"

--- a/src/rpm/headers/header.rs
+++ b/src/rpm/headers/header.rs
@@ -733,7 +733,7 @@ impl IndexData {
             IndexData::Int16(d) => {
                 // align to 2 bytes
 
-                let alignment = if store.len() % 2 != 0 {
+                let alignment = if !store.len().is_multiple_of(2) {
                     store.push(0);
                     1
                 } else {
@@ -748,7 +748,7 @@ impl IndexData {
             IndexData::Int32(d) => {
                 // align to 4 bytes
                 let mut alignment = 0;
-                while store.len() % 4 > 0 {
+                while !store.len().is_multiple_of(4) {
                     store.push(0);
                     alignment += 1;
                 }
@@ -761,7 +761,7 @@ impl IndexData {
             IndexData::Int64(d) => {
                 // align to 8 bytes
                 let mut alignment = 0;
-                while store.len() % 8 > 0 {
+                while !store.len().is_multiple_of(8) {
                     store.push(0);
                     alignment += 1;
                 }

--- a/src/rpm/payload.rs
+++ b/src/rpm/payload.rs
@@ -636,11 +636,11 @@ impl<W: Write> Writer<W> {
     fn do_finish(&mut self) -> io::Result<()> {
         self.try_write_header()?;
 
-        if self.written == self.file_size {
-            if let Some(pad) = pad(self.header_size + self.file_size as usize) {
-                self.inner.write_all(&pad)?;
-                self.inner.flush()?;
-            }
+        if self.written == self.file_size
+            && let Some(pad) = pad(self.header_size + self.file_size as usize)
+        {
+            self.inner.write_all(&pad)?;
+            self.inner.flush()?;
         }
 
         Ok(())

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -10,7 +10,7 @@ mod common;
 #[cfg(target_os = "linux")]
 mod pgp {
     use super::*;
-    use rpm::signature::pgp::{Signer, Verifier};
+    use rpm::signature::pgp::Signer;
 
     #[track_caller]
     fn execute_against_supported_distros(cmd: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -122,7 +122,7 @@ rpm -vv --checksig {pkg_path} 2>&1;"#,
         // TODO: currently only RSA-signed packages are accepted across the full range of supported distros
         // it would be nice to test others here as well, but that requires a bit more finesse
 
-        let mut cmd = String::new();
+        let cmd = String::new();
 
         //         for (pkg_path, pubkey) in &pkgs {
         //             let verifier = Verifier::load_from_asc_bytes(pubkey.as_ref())?;


### PR DESCRIPTION
Fixes #290

This bumps pgp dependency to 0.18.0 and the MSRV to 1.88 because pgp bumped its MSRV

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
