### PR TITLE
Reduce memory by copy file content to writer straight from the archive instead of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Peak memory should be reduced when building packages as files are now read lazily when being added to the package archive.
+- Reduce memory by read file content to writer straight from the archive instead of reading each file entirely into memory before writing them when extract package.
 
 ## Unreleased
 

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -205,10 +205,10 @@ impl std::fmt::Display for CompressionWithLevel {
     }
 }
 
-pub(crate) fn decompress_stream(
+pub(crate) fn decompress_stream<'a>(
     value: CompressionType,
-    reader: impl io::BufRead + 'static,
-) -> Result<Box<dyn io::Read>, Error> {
+    reader: impl io::BufRead + 'a,
+) -> Result<Box<dyn io::Read + 'a>, Error> {
     match value {
         CompressionType::None => Ok(Box::new(reader)),
         #[cfg(feature = "gzip-compression")]


### PR DESCRIPTION
Reduce memory by copy file content straight from the archive to file, instead of reading each file entirely into memory before writing them when extract package. #252

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
