### PR TITLE
Add an attribute for %config(missingok)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Package::signature_key_fingerprints()`
+- The ability to mark files as `%missingok`
 
 ### Changed
 

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -351,6 +351,17 @@ impl FileOptionsBuilder {
         self
     }
 
+    /// Indicates that the absence of a file is not an error during verification.
+    /// During verification (`rpm -V`), a missing file marked with `missingok` will not be
+    /// reported as a failure. During package removal, the file will be silently skipped if
+    /// it does not exist.
+    ///
+    /// See: `%missingok` (or `%config(missingok)`) from specfile syntax
+    pub fn is_missingok(mut self) -> Self {
+        self.inner.flag.insert(FileFlags::MISSINGOK);
+        self
+    }
+
     /// Indicates that a file ought not to actually be included in the package, but that it should
     /// still be considered owned by a package (e.g. a log file).  Its attributes are still tracked.
     ///


### PR DESCRIPTION
closes #219

<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
