### PR TITLE
Use Vec::with_capacity() to avoid resizing during payload read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.25.1
+
 ### Performance
 
 - `Package::open()` now pre-reserves enough space on the payload storage `Vec` to avoid resizing and the accompanying intermediate allocations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Performance
+
+- `Package::open()` now pre-reserves enough space on the payload storage `Vec` to avoid resizing and the accompanying intermediate allocations.
+  - This was seen causing some issues with glibc allocator fragmentation.
+
 ## 0.25.0
 
-## Added
+### Added
 
 - `PackageMetadata::get_file_paths_split()` returns the file paths as `parent_dir`, `filename` pairs.
 - `FileEntry::permissions()`, `FileEntry::user()`, `FileEntry::group()`, `FileEntry::dirname()`, `FileEntry::basename()`
 - `PackageMetadata::for_each_file_entry()` processes file entries via callback without collecting into a `Vec`.
 
-## Breaking Changes
+### Breaking Changes
 
 - `FileEntry` fields are made private, accessor methods are provided instead.
 - `FileEntry::ownership()` not carried over, use `.user()` and `.group()` instead.
@@ -23,21 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FileEntry::path()` now returns `PathBuf` (constructed from dirname + basename) instead of being a stored field.
 - `FileDigest` now borrows from the package header (`FileDigest<'a>`). Use `FileDigest::into_owned()` for a `'static` version.
 
-## Performance
+### Performance
 
 - `FileEntry` uses zero-copy parsing via `Cow<'a, str>`, borrowing string data directly from the RPM header instead of allocating copies. This significantly reduces allocations when iterating file metadata on large packages.
 
-## Misc
+### Misc
 
 - CI now includes an ARM64 runner for Linux, and uploads ARM64 (Aarch64) packages to PyPI.
 
 ## 0.24.0
 
-## Added
+### Added
 
 - `PackageMetadata::get_evr()`
 
-## Removed
+### Removed
 
 - Removed the `Nevra` and `Evr` structs for EVR/NEVRA parsing & sorting. These have been moved to a separate `rpm-version` crate.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpm"
-version = "0.25.0"
+version = "0.25.1"
 authors = [
   "René Richter <richterrettich@gmail.com>",
   "Bernhard Schuster <bernhard@ahoi.io>",

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fs,
-    io::{self, Seek},
+    io::{self, Read, Seek},
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -235,8 +235,14 @@ impl Package {
     /// Open and parse a file at the provided path as an RPM package
     pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
         let rpm_file = fs::File::open(path.as_ref())?;
+        let file_size = rpm_file.metadata()?.len();
         let mut buf_reader = io::BufReader::new(rpm_file);
-        Self::parse(&mut buf_reader)
+        let metadata = PackageMetadata::parse(&mut buf_reader)?;
+        let payload_offset = metadata.get_package_segment_offsets().payload;
+        let payload_size = file_size.saturating_sub(payload_offset) as usize;
+        let mut payload = Vec::with_capacity(payload_size);
+        buf_reader.read_to_end(&mut payload)?;
+        Ok(Package { metadata, payload })
     }
 
     /// Parse an RPM package from an existing buffer


### PR DESCRIPTION


### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled
