### PR TITLE
Find file by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `PackageMetadata::find_file_entry()` looks up a single file entry by path without constructing all entries.
+
 ## 0.26.0
 
 ### Added

--- a/src/python.rs
+++ b/src/python.rs
@@ -952,6 +952,16 @@ impl PyPackageMetadata {
             .map_err(to_pyerr)
     }
 
+    /// Look up a single file entry by its full installation path.
+    ///
+    /// Returns ``None`` if the path is not found or the package has no files.
+    fn find_file_entry(&self, path: &str) -> PyResult<Option<PyFileEntry>> {
+        self.0
+            .find_file_entry(std::path::Path::new(path))
+            .map(|opt| opt.map(|e| PyFileEntry(e.into_owned())))
+            .map_err(to_pyerr)
+    }
+
     // --- Changelog ---
 
     /// List of changelog entries, most recent first.

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -1543,6 +1543,163 @@ impl PackageMetadata {
         Ok(result)
     }
 
+    /// Look up a single file entry by its full installation path.
+    ///
+    /// Returns `Ok(None)` if the path is not found or the package has no files.
+    /// This avoids constructing `FileEntry` objects for every file in the package.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::path::Path;
+    /// let package = rpm::Package::open("tests/assets/RPMS/v4/rpm-basic-2.3.4-5.el9.noarch.rpm")?;
+    /// if let Some(entry) = package.metadata.find_file_entry(Path::new("/usr/bin/rpm-basic"))? {
+    ///     println!("{} is {} bytes", entry.path().display(), entry.size());
+    /// }
+    /// # Ok(()) }
+    /// ```
+    pub fn find_file_entry(&self, path: &Path) -> Result<Option<FileEntry<'_>>, Error> {
+        let search_basename = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => return Ok(None),
+        };
+        let search_dirname = match path.parent().and_then(|p| p.to_str()) {
+            Some(d) => d,
+            None => return Ok(None),
+        };
+        // RPM stores dirnames with a trailing slash
+        let search_dirname_slash = if search_dirname.ends_with('/') {
+            Cow::Borrowed(search_dirname)
+        } else {
+            Cow::Owned(format!("{search_dirname}/"))
+        };
+
+        let basenames = match self
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_BASENAMES)
+        {
+            Ok(b) => b,
+            Err(Error::TagNotFound(_)) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let biject = self
+            .header
+            .get_entry_data_as_u32_array(IndexTag::RPMTAG_DIRINDEXES)?;
+        let dirs = self
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_DIRNAMES)?;
+
+        // Find the dir index that matches the search dirname
+        let target_dir_index = match dirs
+            .iter()
+            .position(|d| *d == search_dirname_slash.as_ref())
+        {
+            Some(idx) => idx as u32,
+            None => return Ok(None),
+        };
+
+        // Find the file index where both basename and dir_index match
+        let file_index = match basenames
+            .iter()
+            .zip(biject.iter())
+            .position(|(bn, di)| *bn == search_basename && *di == target_dir_index)
+        {
+            Some(idx) => idx,
+            None => return Ok(None),
+        };
+
+        // Read the metadata arrays to construct the FileEntry at file_index
+        let algorithm = self
+            .get_file_digest_algorithm()
+            .unwrap_or(DigestAlgorithm::Md5);
+
+        let modes = self
+            .header
+            .get_entry_data_as_u16_array(IndexTag::RPMTAG_FILEMODES)?;
+        let users = self
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEUSERNAME)?;
+        let groups = self
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEGROUPNAME)?;
+        let digests = self
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEDIGESTS)?;
+        let mtimes = self
+            .header
+            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEMTIMES)?;
+        let sizes = self
+            .header
+            .get_entry_data_as_u64_array(IndexTag::RPMTAG_LONGFILESIZES)
+            .or_else(|_e| {
+                self.header
+                    .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILESIZES)
+                    .map(|file_sizes| {
+                        file_sizes
+                            .into_iter()
+                            .map(|file_size| file_size as _)
+                            .collect::<Vec<u64>>()
+                    })
+            })?;
+        let flags = self
+            .header
+            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEFLAGS)?;
+        let links = self
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILELINKTOS)?;
+        let caps = match self
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILECAPS)
+        {
+            Ok(caps) => Some(caps),
+            Err(Error::TagNotFound(_)) => None,
+            Err(e) => return Err(e),
+        };
+        let ima_signatures = match self
+            .signature
+            .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
+        {
+            Ok(ima_signatures) => Some(ima_signatures),
+            Err(Error::TagNotFound(_)) => None,
+            Err(e) => return Err(e),
+        };
+
+        let i = file_index;
+        let digest = if digests[i].is_empty() {
+            None
+        } else {
+            Some(FileDigest::new(algorithm, digests[i])?)
+        };
+        let cap = caps
+            .as_ref()
+            .and_then(|c| c.get(i))
+            .map(|s| Cow::Borrowed(*s));
+        let ima_signature = ima_signatures
+            .as_ref()
+            .and_then(|s| s.get(i))
+            .map(|s| Cow::Borrowed(*s));
+
+        Ok(Some(FileEntry {
+            dirname: Cow::Borrowed(dirs[target_dir_index as usize]),
+            basename: Cow::Borrowed(basenames[i]),
+            user: Cow::Borrowed(users[i]),
+            group: Cow::Borrowed(groups[i]),
+            mode: modes[i].into(),
+            modified_at: crate::Timestamp(mtimes[i]),
+            digest,
+            flags: FileFlags::from_bits_retain(flags[i]),
+            size: sizes[i] as usize,
+            caps: cap,
+            linkto: if links[i].is_empty() {
+                None
+            } else {
+                Some(Cow::Borrowed(links[i]))
+            },
+            ima_signature,
+        }))
+    }
+
     /// Invoke a callback for each file entry in the RPM, without collecting them all into memory.
     ///
     /// This is useful when processing large packages where allocating a `Vec` of all entries

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -1397,148 +1397,14 @@ impl PackageMetadata {
     /// # Ok(()) }
     /// ```
     pub fn get_file_entries(&self) -> Result<Vec<FileEntry<'_>>, Error> {
-        // rpm does not encode it, if it is the default md5
-        let algorithm = self
-            .get_file_digest_algorithm()
-            .unwrap_or(DigestAlgorithm::Md5);
-
-        let modes = match self
-            .header
-            .get_entry_data_as_u16_array(IndexTag::RPMTAG_FILEMODES)
-        {
-            Ok(modes) => modes,
-            Err(Error::TagNotFound(_)) => return Ok(Vec::new()),
-            Err(e) => return Err(e),
+        let arrays = match FileTagArrays::load(self)? {
+            Some(a) => a,
+            None => return Ok(Vec::new()),
         };
-
-        let users = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEUSERNAME)?;
-        let groups = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEGROUPNAME)?;
-        let digests = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEDIGESTS)?;
-        let mtimes = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEMTIMES)?;
-        let sizes = self
-            .header
-            .get_entry_data_as_u64_array(IndexTag::RPMTAG_LONGFILESIZES)
-            .or_else(|_e| {
-                self.header
-                    .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILESIZES)
-                    .map(|file_sizes| {
-                        file_sizes
-                            .into_iter()
-                            .map(|file_size| file_size as _)
-                            .collect::<Vec<u64>>()
-                    })
-            })?;
-        let flags = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEFLAGS)?;
-        let links = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILELINKTOS)?;
-
-        // Optional tags — not present in all packages
-        let caps = match self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILECAPS)
-        {
-            Ok(caps) => Some(caps),
-            Err(Error::TagNotFound(_)) => None,
-            Err(e) => return Err(e),
-        };
-        let ima_signatures = match self
-            .signature
-            .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
-        {
-            Ok(ima_signatures) => Some(ima_signatures),
-            Err(Error::TagNotFound(_)) => None,
-            Err(e) => return Err(e),
-        };
-
-        // Inline path resolution to avoid an intermediate Vec<(&str, &str)>.
-        let basenames_result = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_BASENAMES);
-        let biject_result = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_DIRINDEXES);
-        let dirs_result = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_DIRNAMES);
-
-        if matches!(&basenames_result, Err(Error::TagNotFound(_)))
-            && matches!(&biject_result, Err(Error::TagNotFound(_)))
-            && matches!(&dirs_result, Err(Error::TagNotFound(_)))
-        {
-            return Ok(Vec::new());
-        }
-
-        let basenames = basenames_result?;
-        let biject = biject_result?;
-        let dirs = dirs_result?;
-
-        let n_files = modes.len();
-        if users.len() != n_files
-            || groups.len() != n_files
-            || digests.len() != n_files
-            || mtimes.len() != n_files
-            || sizes.len() != n_files
-            || flags.len() != n_files
-            || links.len() != n_files
-            || basenames.len() != n_files
-            || biject.len() != n_files
-        {
-            return Err(Error::InconsistentTagArrayLengths);
-        }
-
+        let n_files = arrays.len();
         let mut result = Vec::with_capacity(n_files);
         for i in 0..n_files {
-            let dir_index = biject[i] as usize;
-            let dirname = dirs
-                .get(dir_index)
-                .copied()
-                .ok_or_else(|| Error::InvalidTagIndex {
-                    tag: IndexTag::RPMTAG_DIRINDEXES.to_string(),
-                    index: biject[i],
-                    bound: dirs.len() as u32,
-                })?;
-            let digest = if digests[i].is_empty() {
-                None
-            } else {
-                Some(FileDigest::new(algorithm, digests[i])?)
-            };
-            let cap = caps
-                .as_ref()
-                .and_then(|c| c.get(i))
-                .map(|s| Cow::Borrowed(*s));
-            let ima_signature = ima_signatures
-                .as_ref()
-                .and_then(|s| s.get(i))
-                .map(|s| Cow::Borrowed(*s));
-            result.push(FileEntry {
-                dirname: Cow::Borrowed(dirname),
-                basename: Cow::Borrowed(basenames[i]),
-                user: Cow::Borrowed(users[i]),
-                group: Cow::Borrowed(groups[i]),
-                mode: modes[i].into(),
-                modified_at: crate::Timestamp(mtimes[i]),
-                digest,
-                flags: FileFlags::from_bits_retain(flags[i]),
-                size: sizes[i] as usize,
-                caps: cap,
-                linkto: if links[i].is_empty() {
-                    None
-                } else {
-                    Some(Cow::Borrowed(links[i]))
-                },
-                ima_signature,
-            });
+            result.push(arrays.entry(i)?);
         }
         Ok(result)
     }
@@ -1575,23 +1441,14 @@ impl PackageMetadata {
             Cow::Owned(format!("{search_dirname}/"))
         };
 
-        let basenames = match self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_BASENAMES)
-        {
-            Ok(b) => b,
-            Err(Error::TagNotFound(_)) => return Ok(None),
-            Err(e) => return Err(e),
+        let arrays = match FileTagArrays::load(self)? {
+            Some(a) => a,
+            None => return Ok(None),
         };
-        let biject = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_DIRINDEXES)?;
-        let dirs = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_DIRNAMES)?;
 
         // Find the dir index that matches the search dirname
-        let target_dir_index = match dirs
+        let target_dir_index = match arrays
+            .dirs
             .iter()
             .position(|d| *d == search_dirname_slash.as_ref())
         {
@@ -1600,104 +1457,17 @@ impl PackageMetadata {
         };
 
         // Find the file index where both basename and dir_index match
-        let file_index = match basenames
+        let file_index = match arrays
+            .basenames
             .iter()
-            .zip(biject.iter())
+            .zip(arrays.biject.iter())
             .position(|(bn, di)| *bn == search_basename && *di == target_dir_index)
         {
             Some(idx) => idx,
             None => return Ok(None),
         };
 
-        // Read the metadata arrays to construct the FileEntry at file_index
-        let algorithm = self
-            .get_file_digest_algorithm()
-            .unwrap_or(DigestAlgorithm::Md5);
-
-        let modes = self
-            .header
-            .get_entry_data_as_u16_array(IndexTag::RPMTAG_FILEMODES)?;
-        let users = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEUSERNAME)?;
-        let groups = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEGROUPNAME)?;
-        let digests = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEDIGESTS)?;
-        let mtimes = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEMTIMES)?;
-        let sizes = self
-            .header
-            .get_entry_data_as_u64_array(IndexTag::RPMTAG_LONGFILESIZES)
-            .or_else(|_e| {
-                self.header
-                    .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILESIZES)
-                    .map(|file_sizes| {
-                        file_sizes
-                            .into_iter()
-                            .map(|file_size| file_size as _)
-                            .collect::<Vec<u64>>()
-                    })
-            })?;
-        let flags = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEFLAGS)?;
-        let links = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILELINKTOS)?;
-        let caps = match self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILECAPS)
-        {
-            Ok(caps) => Some(caps),
-            Err(Error::TagNotFound(_)) => None,
-            Err(e) => return Err(e),
-        };
-        let ima_signatures = match self
-            .signature
-            .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
-        {
-            Ok(ima_signatures) => Some(ima_signatures),
-            Err(Error::TagNotFound(_)) => None,
-            Err(e) => return Err(e),
-        };
-
-        let i = file_index;
-        let digest = if digests[i].is_empty() {
-            None
-        } else {
-            Some(FileDigest::new(algorithm, digests[i])?)
-        };
-        let cap = caps
-            .as_ref()
-            .and_then(|c| c.get(i))
-            .map(|s| Cow::Borrowed(*s));
-        let ima_signature = ima_signatures
-            .as_ref()
-            .and_then(|s| s.get(i))
-            .map(|s| Cow::Borrowed(*s));
-
-        Ok(Some(FileEntry {
-            dirname: Cow::Borrowed(dirs[target_dir_index as usize]),
-            basename: Cow::Borrowed(basenames[i]),
-            user: Cow::Borrowed(users[i]),
-            group: Cow::Borrowed(groups[i]),
-            mode: modes[i].into(),
-            modified_at: crate::Timestamp(mtimes[i]),
-            digest,
-            flags: FileFlags::from_bits_retain(flags[i]),
-            size: sizes[i] as usize,
-            caps: cap,
-            linkto: if links[i].is_empty() {
-                None
-            } else {
-                Some(Cow::Borrowed(links[i]))
-            },
-            ima_signature,
-        }))
+        Ok(Some(arrays.entry(file_index)?))
     }
 
     /// Invoke a callback for each file entry in the RPM, without collecting them all into memory.
@@ -1720,149 +1490,13 @@ impl PackageMetadata {
         &self,
         mut f: impl FnMut(FileEntry<'_>) -> Result<(), Error>,
     ) -> Result<(), Error> {
-        // rpm does not encode it, if it is the default md5
-        let algorithm = self
-            .get_file_digest_algorithm()
-            .unwrap_or(DigestAlgorithm::Md5);
-
-        let modes = match self
-            .header
-            .get_entry_data_as_u16_array(IndexTag::RPMTAG_FILEMODES)
-        {
-            Ok(modes) => modes,
-            Err(Error::TagNotFound(_)) => return Ok(()),
-            Err(e) => return Err(e),
+        let arrays = match FileTagArrays::load(self)? {
+            Some(a) => a,
+            None => return Ok(()),
         };
-
-        let users = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEUSERNAME)?;
-        let groups = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEGROUPNAME)?;
-        let digests = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEDIGESTS)?;
-        let mtimes = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEMTIMES)?;
-        let sizes = self
-            .header
-            .get_entry_data_as_u64_array(IndexTag::RPMTAG_LONGFILESIZES)
-            .or_else(|_e| {
-                self.header
-                    .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILESIZES)
-                    .map(|file_sizes| {
-                        file_sizes
-                            .into_iter()
-                            .map(|file_size| file_size as _)
-                            .collect::<Vec<u64>>()
-                    })
-            })?;
-        let flags = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEFLAGS)?;
-        let links = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILELINKTOS)?;
-
-        // Optional tags — not present in all packages
-        let caps = match self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILECAPS)
-        {
-            Ok(caps) => Some(caps),
-            Err(Error::TagNotFound(_)) => None,
-            Err(e) => return Err(e),
-        };
-        let ima_signatures = match self
-            .signature
-            .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
-        {
-            Ok(ima_signatures) => Some(ima_signatures),
-            Err(Error::TagNotFound(_)) => None,
-            Err(e) => return Err(e),
-        };
-
-        // Inline path resolution to avoid an intermediate Vec<(&str, &str)>.
-        let basenames_result = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_BASENAMES);
-        let biject_result = self
-            .header
-            .get_entry_data_as_u32_array(IndexTag::RPMTAG_DIRINDEXES);
-        let dirs_result = self
-            .header
-            .get_entry_data_as_string_array(IndexTag::RPMTAG_DIRNAMES);
-
-        if matches!(&basenames_result, Err(Error::TagNotFound(_)))
-            && matches!(&biject_result, Err(Error::TagNotFound(_)))
-            && matches!(&dirs_result, Err(Error::TagNotFound(_)))
-        {
-            return Ok(());
+        for i in 0..arrays.len() {
+            f(arrays.entry(i)?)?;
         }
-
-        let basenames = basenames_result?;
-        let biject = biject_result?;
-        let dirs = dirs_result?;
-
-        let n_files = modes.len();
-        if users.len() != n_files
-            || groups.len() != n_files
-            || digests.len() != n_files
-            || mtimes.len() != n_files
-            || sizes.len() != n_files
-            || flags.len() != n_files
-            || links.len() != n_files
-            || basenames.len() != n_files
-            || biject.len() != n_files
-        {
-            return Err(Error::InconsistentTagArrayLengths);
-        }
-
-        for i in 0..n_files {
-            let dir_index = biject[i] as usize;
-            let dirname = dirs
-                .get(dir_index)
-                .copied()
-                .ok_or_else(|| Error::InvalidTagIndex {
-                    tag: IndexTag::RPMTAG_DIRINDEXES.to_string(),
-                    index: biject[i],
-                    bound: dirs.len() as u32,
-                })?;
-            let digest = if digests[i].is_empty() {
-                None
-            } else {
-                Some(FileDigest::new(algorithm, digests[i])?)
-            };
-            let cap = caps
-                .as_ref()
-                .and_then(|c| c.get(i))
-                .map(|s| Cow::Borrowed(*s));
-            let ima_signature = ima_signatures
-                .as_ref()
-                .and_then(|s| s.get(i))
-                .map(|s| Cow::Borrowed(*s));
-            f(FileEntry {
-                dirname: Cow::Borrowed(dirname),
-                basename: Cow::Borrowed(basenames[i]),
-                user: Cow::Borrowed(users[i]),
-                group: Cow::Borrowed(groups[i]),
-                mode: modes[i].into(),
-                modified_at: crate::Timestamp(mtimes[i]),
-                digest,
-                flags: FileFlags::from_bits_retain(flags[i]),
-                size: sizes[i] as usize,
-                caps: cap,
-                linkto: if links[i].is_empty() {
-                    None
-                } else {
-                    Some(Cow::Borrowed(links[i]))
-                },
-                ima_signature,
-            })?;
-        }
-
         Ok(())
     }
 
@@ -2050,6 +1684,194 @@ impl PackageMetadata {
         Ok(SignatureReport {
             digests,
             signatures,
+        })
+    }
+}
+
+struct FileTagArrays<'a> {
+    algorithm: DigestAlgorithm,
+    modes: Vec<u16>,
+    users: Vec<&'a str>,
+    groups: Vec<&'a str>,
+    digests: Vec<&'a str>,
+    mtimes: Vec<u32>,
+    sizes: Vec<u64>,
+    flags: Vec<u32>,
+    links: Vec<&'a str>,
+    caps: Option<Vec<&'a str>>,
+    ima_signatures: Option<Vec<&'a str>>,
+    basenames: Vec<&'a str>,
+    biject: Vec<u32>,
+    dirs: Vec<&'a str>,
+}
+
+impl<'a> FileTagArrays<'a> {
+    /// Load all file-related tag arrays from the package metadata.
+    /// Returns `Ok(None)` if the package has no files.
+    fn load(meta: &'a PackageMetadata) -> Result<Option<Self>, Error> {
+        let algorithm = meta
+            .get_file_digest_algorithm()
+            .unwrap_or(DigestAlgorithm::Md5);
+
+        let modes = match meta
+            .header
+            .get_entry_data_as_u16_array(IndexTag::RPMTAG_FILEMODES)
+        {
+            Ok(modes) => modes,
+            Err(Error::TagNotFound(_)) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+
+        let users = meta
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEUSERNAME)?;
+        let groups = meta
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEGROUPNAME)?;
+        let digests = meta
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEDIGESTS)?;
+        let mtimes = meta
+            .header
+            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEMTIMES)?;
+        let sizes = meta
+            .header
+            .get_entry_data_as_u64_array(IndexTag::RPMTAG_LONGFILESIZES)
+            .or_else(|_e| {
+                meta.header
+                    .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILESIZES)
+                    .map(|file_sizes| {
+                        file_sizes
+                            .into_iter()
+                            .map(|file_size| file_size as _)
+                            .collect::<Vec<u64>>()
+                    })
+            })?;
+        let flags = meta
+            .header
+            .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEFLAGS)?;
+        let links = meta
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILELINKTOS)?;
+
+        let caps = match meta
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_FILECAPS)
+        {
+            Ok(caps) => Some(caps),
+            Err(Error::TagNotFound(_)) => None,
+            Err(e) => return Err(e),
+        };
+        let ima_signatures = match meta
+            .signature
+            .get_entry_data_as_string_array(IndexSignatureTag::RPMSIGTAG_FILESIGNATURES)
+        {
+            Ok(ima_signatures) => Some(ima_signatures),
+            Err(Error::TagNotFound(_)) => None,
+            Err(e) => return Err(e),
+        };
+
+        let basenames_result = meta
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_BASENAMES);
+        let biject_result = meta
+            .header
+            .get_entry_data_as_u32_array(IndexTag::RPMTAG_DIRINDEXES);
+        let dirs_result = meta
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_DIRNAMES);
+
+        if matches!(&basenames_result, Err(Error::TagNotFound(_)))
+            && matches!(&biject_result, Err(Error::TagNotFound(_)))
+            && matches!(&dirs_result, Err(Error::TagNotFound(_)))
+        {
+            return Ok(None);
+        }
+
+        let basenames = basenames_result?;
+        let biject = biject_result?;
+        let dirs = dirs_result?;
+
+        let n_files = modes.len();
+        if users.len() != n_files
+            || groups.len() != n_files
+            || digests.len() != n_files
+            || mtimes.len() != n_files
+            || sizes.len() != n_files
+            || flags.len() != n_files
+            || links.len() != n_files
+            || basenames.len() != n_files
+            || biject.len() != n_files
+        {
+            return Err(Error::InconsistentTagArrayLengths);
+        }
+
+        Ok(Some(FileTagArrays {
+            algorithm,
+            modes,
+            users,
+            groups,
+            digests,
+            mtimes,
+            sizes,
+            flags,
+            links,
+            caps,
+            ima_signatures,
+            basenames,
+            biject,
+            dirs,
+        }))
+    }
+
+    fn len(&self) -> usize {
+        self.modes.len()
+    }
+
+    fn entry(&self, i: usize) -> Result<FileEntry<'a>, Error> {
+        let dir_index = self.biject[i] as usize;
+        let dirname = self
+            .dirs
+            .get(dir_index)
+            .copied()
+            .ok_or_else(|| Error::InvalidTagIndex {
+                tag: IndexTag::RPMTAG_DIRINDEXES.to_string(),
+                index: self.biject[i],
+                bound: self.dirs.len() as u32,
+            })?;
+        let digest = if self.digests[i].is_empty() {
+            None
+        } else {
+            Some(FileDigest::new(self.algorithm, self.digests[i])?)
+        };
+        let cap = self
+            .caps
+            .as_ref()
+            .and_then(|c| c.get(i))
+            .map(|s| Cow::Borrowed(*s));
+        let ima_signature = self
+            .ima_signatures
+            .as_ref()
+            .and_then(|s| s.get(i))
+            .map(|s| Cow::Borrowed(*s));
+
+        Ok(FileEntry {
+            dirname: Cow::Borrowed(dirname),
+            basename: Cow::Borrowed(self.basenames[i]),
+            user: Cow::Borrowed(self.users[i]),
+            group: Cow::Borrowed(self.groups[i]),
+            mode: self.modes[i].into(),
+            modified_at: crate::Timestamp(self.mtimes[i]),
+            digest,
+            flags: FileFlags::from_bits_retain(self.flags[i]),
+            size: self.sizes[i] as usize,
+            caps: cap,
+            linkto: if self.links[i].is_empty() {
+                None
+            } else {
+                Some(Cow::Borrowed(self.links[i]))
+            },
+            ima_signature,
         })
     }
 }

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -1177,3 +1177,36 @@ fn test_tag_not_found_display() {
         "expected tag name in error: {msg}"
     );
 }
+
+#[test]
+fn test_find_file_entry() -> Result<(), Box<dyn std::error::Error>> {
+    let pkg = Package::open(common::pkgs::v4::RPM_BASIC)?;
+
+    // Find an existing file
+    let entry = pkg
+        .metadata
+        .find_file_entry(Path::new("/etc/rpm-basic/example_config.toml"))?
+        .expect("config file should be found");
+    assert_eq!(entry.basename(), "example_config.toml");
+    assert_eq!(entry.dirname(), "/etc/rpm-basic/");
+    assert_eq!(entry.size(), 31);
+    assert!(entry.flags().contains(FileFlags::CONFIG));
+
+    // Nonexistent path returns None
+    assert!(
+        pkg.metadata
+            .find_file_entry(Path::new("/nonexistent/path"))?
+            .is_none()
+    );
+
+    // Empty package returns None
+    let empty = Package::open(common::pkgs::v4::RPM_EMPTY)?;
+    assert!(
+        empty
+            .metadata
+            .find_file_entry(Path::new("/anything"))?
+            .is_none()
+    );
+
+    Ok(())
+}

--- a/tests/python/test_metadata.py
+++ b/tests/python/test_metadata.py
@@ -253,6 +253,22 @@ class TestFiles:
         assert len(m.file_paths()) == 0
         assert len(m.file_entries()) == 0
 
+    def test_find_file_entry(self):
+        m = PackageMetadata.open(RPM_BASIC)
+        entry = m.find_file_entry("/etc/rpm-basic/example_config.toml")
+        assert entry is not None
+        assert isinstance(entry, FileEntry)
+        assert entry.path == "/etc/rpm-basic/example_config.toml"
+        assert entry.size == 31
+
+    def test_find_file_entry_not_found(self):
+        m = PackageMetadata.open(RPM_BASIC)
+        assert m.find_file_entry("/nonexistent/path") is None
+
+    def test_find_file_entry_empty_package(self):
+        m = PackageMetadata.open(RPM_EMPTY)
+        assert m.find_file_entry("/anything") is None
+
 
 class TestScriptlets:
     def test_scriptlets_present(self):


### PR DESCRIPTION
Looks up a single file entry by its full installation path, avoiding the need to construct FileEntry objects for every file in the package.

Assisted-By: Claude Opus 4.6

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
