### PR TITLE
Add Package::decompress_payload() and ALT digest verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Package::decompress_payload()` decompresses the payload in-place, replacing compressed bytes with the raw archive.
+- `DigestReport` now includes ALT payload digest fields (`payload_sha256_alt`, `payload_sha512_alt`, `payload_sha3_256_alt`) for verifying uncompressed payloads. `DigestReport::result()` uses "either-set" semantics — the payload is valid if either the primary (compressed) or ALT (uncompressed) digest set passes.
 - `PackageMetadata::find_file_entry()` looks up a single file entry by path without constructing all entries.
 
 ## 0.26.0

--- a/src/python.rs
+++ b/src/python.rs
@@ -1347,6 +1347,17 @@ impl PyPackage {
         self.0.check_digests().map(PyDigestReport).map_err(to_pyerr)
     }
 
+    /// Decompress the payload in-place, replacing compressed bytes with
+    /// the raw (uncompressed) archive.
+    ///
+    /// The package metadata is not modified. Use ``check_digests()`` with the
+    /// ALT payload digest fields to verify the uncompressed payload.
+    ///
+    /// No-op if the payload is already uncompressed.
+    fn decompress_payload(&mut self) -> PyResult<()> {
+        self.0.decompress_payload().map_err(to_pyerr)
+    }
+
     /// Apply a pre-computed signature to this package.
     ///
     /// The raw OpenPGP signature bytes are added to the signature header.
@@ -1785,6 +1796,24 @@ impl PyDigestReport {
     #[getter]
     fn payload_sha3_256(&self) -> PyDigestStatus {
         PyDigestStatus(self.0.payload_sha3_256.clone())
+    }
+
+    /// SHA-256 of the uncompressed payload archive.
+    #[getter]
+    fn payload_sha256_alt(&self) -> PyDigestStatus {
+        PyDigestStatus(self.0.payload_sha256_alt.clone())
+    }
+
+    /// SHA-512 of the uncompressed payload archive (v6 packages).
+    #[getter]
+    fn payload_sha512_alt(&self) -> PyDigestStatus {
+        PyDigestStatus(self.0.payload_sha512_alt.clone())
+    }
+
+    /// SHA3-256 of the uncompressed payload archive (v6 packages).
+    #[getter]
+    fn payload_sha3_256_alt(&self) -> PyDigestStatus {
+        PyDigestStatus(self.0.payload_sha3_256_alt.clone())
     }
 
     /// True if at least one header digest was present.

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -107,6 +107,12 @@ pub struct DigestReport {
     pub payload_sha512: DigestStatus,
     /// SHA3-256 of the compressed payload (v6 packages).
     pub payload_sha3_256: DigestStatus,
+    /// SHA-256 of the uncompressed payload archive.
+    pub payload_sha256_alt: DigestStatus,
+    /// SHA-512 of the uncompressed payload archive (v6 packages).
+    pub payload_sha512_alt: DigestStatus,
+    /// SHA3-256 of the uncompressed payload archive (v6 packages).
+    pub payload_sha3_256_alt: DigestStatus,
 }
 
 impl DigestReport {
@@ -122,23 +128,30 @@ impl DigestReport {
         !self.payload_sha256.is_not_present()
             || !self.payload_sha512.is_not_present()
             || !self.payload_sha3_256.is_not_present()
+            || !self.payload_sha256_alt.is_not_present()
+            || !self.payload_sha512_alt.is_not_present()
+            || !self.payload_sha3_256_alt.is_not_present()
     }
 
     /// Collapse into a `Result`: fails if any digest mismatched or if no
     /// header digests are present at all.
     ///
-    /// Digests that are [`DigestStatus::NotPresent`] are **not** individually
-    /// considered failures, but at least one header digest must be present.
+    /// Header digests are strict: any mismatch is a failure.
+    ///
+    /// Payload digests use "either-set" semantics: the primary set (compressed
+    /// payload digests) and the ALT set (uncompressed payload digests) are
+    /// evaluated independently. A set passes if it contains at least one
+    /// [`DigestStatus::Verified`] and no [`DigestStatus::Mismatch`] entries.
+    /// The payload is considered valid if either set passes. This allows
+    /// verification to succeed both before and after
+    /// [`Package::decompress_payload`].
     pub fn result(&self) -> Result<(), Error> {
-        let all = [
+        let header_digests: [(&str, &DigestStatus); 3] = [
             ("header SHA1", &self.header_sha1),
             ("header SHA-256", &self.header_sha256),
             ("header SHA3-256", &self.header_sha3_256),
-            ("payload SHA-256", &self.payload_sha256),
-            ("payload SHA-512", &self.payload_sha512),
-            ("payload SHA3-256", &self.payload_sha3_256),
         ];
-        for (label, status) in all {
+        for (label, status) in &header_digests {
             if let DigestStatus::Mismatch { expected, actual } = status {
                 return Err(Error::DigestMismatchError {
                     digest: label,
@@ -147,6 +160,38 @@ impl DigestReport {
                 });
             }
         }
+
+        let primary: [(&str, &DigestStatus); 3] = [
+            ("payload SHA-256", &self.payload_sha256),
+            ("payload SHA-512", &self.payload_sha512),
+            ("payload SHA3-256", &self.payload_sha3_256),
+        ];
+        let alt: [(&str, &DigestStatus); 3] = [
+            ("payload SHA-256 (alt)", &self.payload_sha256_alt),
+            ("payload SHA-512 (alt)", &self.payload_sha512_alt),
+            ("payload SHA3-256 (alt)", &self.payload_sha3_256_alt),
+        ];
+
+        let set_passes = |set: &[(&str, &DigestStatus)]| -> bool {
+            let has_verified = set.iter().any(|(_, s)| s.is_verified());
+            let has_mismatch = set.iter().any(|(_, s)| s.is_mismatch());
+            has_verified && !has_mismatch
+        };
+
+        if set_passes(&primary) || set_passes(&alt) {
+            return Ok(());
+        }
+
+        for (label, status) in primary.iter().chain(alt.iter()) {
+            if let DigestStatus::Mismatch { expected, actual } = status {
+                return Err(Error::DigestMismatchError {
+                    digest: label,
+                    expected: expected.clone(),
+                    actual: actual.clone(),
+                });
+            }
+        }
+
         Ok(())
     }
 
@@ -318,6 +363,29 @@ impl Package {
     /// Delegates to [`PackageMetadata::header_bytes`].
     pub fn header_bytes(&self) -> Result<Vec<u8>, Error> {
         self.metadata.header_bytes()
+    }
+
+    /// Decompress the payload in-place, replacing the compressed bytes with
+    /// the raw (uncompressed) archive.
+    ///
+    /// After this call, `self.payload` contains the uncompressed CPIO archive.
+    /// The package metadata is **not** modified — the `PAYLOADCOMPRESSOR` tag
+    /// and primary digest tags still reflect the original compressed form.
+    /// Use [`check_digests`](Self::check_digests) with the ALT payload digest
+    /// fields to verify the uncompressed payload.
+    ///
+    /// This is a no-op if the payload compressor is already [`CompressionType::None`].
+    #[cfg(feature = "payload")]
+    pub fn decompress_payload(&mut self) -> Result<(), Error> {
+        let compressor = self.metadata.get_payload_compressor()?;
+        if compressor == CompressionType::None {
+            return Ok(());
+        }
+        let mut decompressed = Vec::new();
+        crate::decompress_stream(compressor, io::Cursor::new(self.payload.as_slice()))?
+            .read_to_end(&mut decompressed)?;
+        self.payload = decompressed;
+        Ok(())
     }
 
     /// Generate a fresh, unsigned signature header
@@ -649,6 +717,29 @@ impl Package {
             self.metadata
                 .header
                 .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOAD_SHA3_256),
+            self.payload.as_slice(),
+        );
+
+        // --- Payload ALT digests (uncompressed archive, from main header) ---
+
+        report.payload_sha256_alt = DigestStatus::check_digest_against_tag::<sha2::Sha256>(
+            self.metadata
+                .header
+                .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOADSHA256ALT),
+            self.payload.as_slice(),
+        );
+
+        report.payload_sha512_alt = DigestStatus::check_digest_against_tag::<sha2::Sha512>(
+            self.metadata
+                .header
+                .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOAD_SHA512_ALT),
+            self.payload.as_slice(),
+        );
+
+        report.payload_sha3_256_alt = DigestStatus::check_digest_against_tag::<sha3::Sha3_256>(
+            self.metadata
+                .header
+                .get_entry_data_as_string(IndexTag::RPMTAG_PAYLOAD_SHA3_256_ALT),
             self.payload.as_slice(),
         );
 
@@ -1624,6 +1715,9 @@ impl PackageMetadata {
             payload_sha256: DigestStatus::NotChecked,
             payload_sha512: DigestStatus::NotChecked,
             payload_sha3_256: DigestStatus::NotChecked,
+            payload_sha256_alt: DigestStatus::NotChecked,
+            payload_sha512_alt: DigestStatus::NotChecked,
+            payload_sha3_256_alt: DigestStatus::NotChecked,
         })
     }
 

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -369,10 +369,14 @@ impl Package {
     /// the raw (uncompressed) archive.
     ///
     /// After this call, `self.payload` contains the uncompressed CPIO archive.
-    /// The package metadata is **not** modified — the `PAYLOADCOMPRESSOR` tag
-    /// and primary digest tags still reflect the original compressed form.
-    /// Use [`check_digests`](Self::check_digests) with the ALT payload digest
+    /// The main header is **not** modified — the `PAYLOADCOMPRESSOR` tag and
+    /// primary digest tags still reflect the original compressed form. Use
+    /// [`check_digests`](Self::check_digests) with the ALT payload digest
     /// fields to verify the uncompressed payload.
+    ///
+    /// The signature header is rebuilt to update the header+payload length and strip
+    /// legacy header+payload tags (MD5, PGP/GPG) that are invalidated by the
+    /// payload change. Header-only signatures and digests are preserved.
     ///
     /// This is a no-op if the payload compressor is already [`CompressionType::None`].
     #[cfg(feature = "payload")]
@@ -385,6 +389,13 @@ impl Package {
         crate::decompress_stream(compressor, io::Cursor::new(self.payload.as_slice()))?
             .read_to_end(&mut decompressed)?;
         self.payload = decompressed;
+
+        let header_bytes = self.header_bytes()?;
+        let content_length = header_bytes.len() as u64 + self.payload.len() as u64;
+        self.metadata.signature = SignatureHeaderBuilder::from_existing(&self.metadata.signature)?
+            .set_content_length(content_length)
+            .build()?;
+
         Ok(())
     }
 

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -673,9 +673,16 @@ fn test_verify_digests_standalone() -> Result<(), Box<dyn std::error::Error>> {
     assert!(report.payload_sha256.is_verified());
     assert!(report.payload_sha512.is_not_present());
     assert!(report.payload_sha3_256.is_not_present());
+    // v4 fixtures built by rpmbuild may not have ALT tags
+    assert!(
+        report.payload_sha256_alt.is_not_present()
+            || report.payload_sha256_alt.is_verified()
+            || report.payload_sha256_alt.is_mismatch()
+    );
     assert!(report.is_ok());
 
-    // check_digests() on a v6 package: SHA3-256 present, SHA-1 not present
+    // check_digests() on a v6 package (uncompressed): SHA3-256 present, SHA-1 not present
+    // Both primary and ALT digests verify because payload == uncompressed archive
     let report = rpm::Package::open(common::pkgs::v6::RPM_BASIC)?.check_digests()?;
     assert!(report.header_sha256.is_verified());
     assert!(report.header_sha3_256.is_verified());
@@ -683,6 +690,9 @@ fn test_verify_digests_standalone() -> Result<(), Box<dyn std::error::Error>> {
     assert!(report.payload_sha256.is_verified());
     assert!(report.payload_sha512.is_verified());
     assert!(report.payload_sha3_256.is_verified());
+    assert!(report.payload_sha256_alt.is_verified());
+    assert!(report.payload_sha512_alt.is_verified());
+    assert!(report.payload_sha3_256_alt.is_verified());
     assert!(report.is_ok());
 
     Ok(())
@@ -1108,6 +1118,74 @@ fn test_clear_signatures_preserves_digests_and_file_signatures()
     Ok(())
 }
 
+/// Test that decompress_payload() decompresses in-place and ALT digests verify
+#[test]
+fn test_decompress_payload_and_verify() -> Result<(), Box<dyn std::error::Error>> {
+    let mut pkg = rpm::Package::open(common::pkgs::v6::compressed::RPM_BASIC_ZSTD)?;
+
+    // Before decompression: primary digests verify
+    let report = pkg.check_digests()?;
+    assert!(report.payload_sha256.is_verified());
+    assert!(report.payload_sha512.is_verified());
+    assert!(report.payload_sha3_256.is_verified());
+    // ALT digests mismatch (payload is compressed, ALT is for uncompressed)
+    assert!(report.payload_sha256_alt.is_mismatch());
+    assert!(report.payload_sha512_alt.is_mismatch());
+    assert!(report.payload_sha3_256_alt.is_mismatch());
+    // Overall verification passes (primary set passes)
+    assert!(report.is_ok());
+    pkg.verify_digests()?;
+
+    // Decompress
+    pkg.decompress_payload()?;
+
+    // After decompression: ALT digests verify, primary digests mismatch
+    let report = pkg.check_digests()?;
+    assert!(report.payload_sha256.is_mismatch());
+    assert!(report.payload_sha256_alt.is_verified());
+    assert!(report.payload_sha512_alt.is_verified());
+    assert!(report.payload_sha3_256_alt.is_verified());
+    // Overall verification passes (ALT set passes)
+    assert!(report.is_ok());
+    pkg.verify_digests()?;
+
+    // Header digests should still be fine
+    assert!(report.header_sha256.is_verified());
+    assert!(report.header_sha3_256.is_verified());
+
+    Ok(())
+}
+
+/// Test decompress_payload() with different compression formats
+#[test]
+fn test_decompress_payload_formats() -> Result<(), Box<dyn std::error::Error>> {
+    for path in [
+        common::pkgs::v6::compressed::RPM_BASIC_ZSTD,
+        common::pkgs::v6::compressed::RPM_BASIC_GZIP,
+        common::pkgs::v6::compressed::RPM_BASIC_XZ,
+    ] {
+        let mut pkg = rpm::Package::open(path)?;
+        pkg.verify_digests()?;
+        pkg.decompress_payload()?;
+        pkg.verify_digests()?;
+    }
+    Ok(())
+}
+
+/// Test that decompress_payload() is a no-op for uncompressed packages
+#[test]
+fn test_decompress_payload_noop_for_uncompressed() -> Result<(), Box<dyn std::error::Error>> {
+    let mut pkg = rpm::Package::open(common::pkgs::v6::RPM_BASIC)?;
+    let original_payload = pkg.payload.clone();
+
+    pkg.decompress_payload()?;
+
+    assert_eq!(pkg.payload, original_payload);
+    pkg.verify_digests()?;
+
+    Ok(())
+}
+
 mod tampering {
     use super::*;
 
@@ -1178,6 +1256,29 @@ mod tampering {
         assert!(report.payload_sha256.is_mismatch());
         assert!(report.header_sha256.is_verified());
         assert!(report.header_sha3_256.is_verified());
+
+        Ok(())
+    }
+
+    /// Test that tampering with a decompressed payload is detected
+    #[test]
+    fn test_tampered_decompressed_payload_detected() -> Result<(), Box<dyn std::error::Error>> {
+        let mut pkg = rpm::Package::open(common::pkgs::v6::compressed::RPM_BASIC_ZSTD)?;
+
+        pkg.decompress_payload()?;
+        pkg.verify_digests()?;
+
+        // Tamper with the decompressed payload
+        if let Some(byte) = pkg.payload.last_mut() {
+            *byte ^= 0xFF;
+        }
+
+        // Both primary and ALT should mismatch
+        let report = pkg.check_digests()?;
+        assert!(report.payload_sha256.is_mismatch());
+        assert!(report.payload_sha256_alt.is_mismatch());
+        assert!(!report.is_ok());
+        assert!(pkg.verify_digests().is_err());
 
         Ok(())
     }

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -1121,6 +1121,14 @@ fn test_clear_signatures_preserves_digests_and_file_signatures()
 /// Test that decompress_payload() decompresses in-place and ALT digests verify
 #[test]
 fn test_decompress_payload_and_verify() -> Result<(), Box<dyn std::error::Error>> {
+    let sig_content_length = |sig: &rpm::Header<rpm::IndexSignatureTag>| -> Option<u64> {
+        sig.get_entry_data_as_u32(rpm::IndexSignatureTag::RPMSIGTAG_SIZE)
+            .map(|v| v as u64)
+            .or_else(|_| sig.get_entry_data_as_u64(rpm::IndexSignatureTag::RPMSIGTAG_LONGSIZE))
+            .ok()
+    };
+
+    // --- v6 compressed fixture: full ALT digest coverage ---
     let mut pkg = rpm::Package::open(common::pkgs::v6::compressed::RPM_BASIC_ZSTD)?;
 
     // Before decompression: primary digests verify
@@ -1152,6 +1160,49 @@ fn test_decompress_payload_and_verify() -> Result<(), Box<dyn std::error::Error>
     // Header digests should still be fine
     assert!(report.header_sha256.is_verified());
     assert!(report.header_sha3_256.is_verified());
+
+    // Signature header should have been rebuilt: legacy header+payload tags stripped
+    let sig = &pkg.metadata.signature;
+    assert!(
+        !sig.entry_is_present(rpm::IndexSignatureTag::RPMSIGTAG_MD5),
+        "legacy MD5 tag should be stripped"
+    );
+    assert!(
+        !sig.entry_is_present(rpm::IndexSignatureTag::RPMSIGTAG_PGP),
+        "legacy PGP tag should be stripped"
+    );
+    assert!(
+        !sig.entry_is_present(rpm::IndexSignatureTag::RPMSIGTAG_GPG),
+        "legacy GPG tag should be stripped"
+    );
+
+    // --- v4 built package: content-length update ---
+    let mut pkg = rpm::PackageBuilder::new("foo", "1.0.0", "MIT", "x86_64", "decompress test")
+        .using_config(rpm::BuildConfig::v4().compression(rpm::CompressionType::Zstd))
+        .build()?;
+    pkg.verify_digests()?;
+
+    let content_length_before = sig_content_length(&pkg.metadata.signature);
+    assert!(
+        content_length_before.is_some(),
+        "v4 package should have content-length"
+    );
+
+    pkg.decompress_payload()?;
+    pkg.verify_digests()?;
+
+    let header_bytes = pkg.header_bytes()?;
+    let expected_content_length = header_bytes.len() as u64 + pkg.payload.len() as u64;
+    let content_length_after = sig_content_length(&pkg.metadata.signature);
+    assert_eq!(
+        content_length_after,
+        Some(expected_content_length),
+        "content-length should reflect decompressed payload"
+    );
+    assert_ne!(
+        content_length_after, content_length_before,
+        "content-length should have changed after decompression"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Add a method to decompress the payload in-place, leaving the raw (uncompressed) CPIO archive as the payload. The package metadata is not modified, so the PAYLOADCOMPRESSOR tag and primary digest tags still reflect the original compressed form.

Extend DigestReport with ALT payload digest fields (sha256_alt, sha512_alt, sha3_256_alt) that verify the uncompressed archive. DigestReport::result() now uses "either-set" semantics: the payload is valid if either the primary (compressed) or ALT (uncompressed) digest set has at least one verified entry with no mismatches. This allows verification to succeed both before and after decompression.

Assisted-By: Claude Opus 4.6

### 📜 Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry or entries has been added to CHANGELOG.md
- [x] Documentation is thorough
- [x] Test coverage is excellent and passes
- [x] Works when tests are run `--all-features` enabled
