### PR TITLE
Add optional Sequoia signature backend

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,4 @@ are wanted, state them here or leave comments below.
 - [ ] A changelog entry or entries has been added to CHANGELOG.md
 - [ ] Documentation is thorough
 - [ ] Test coverage is excellent and passes
-- [ ] Works when tests are run `--all-features` enabled
+- [ ] Works with each applicable signature backend enabled separately

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
           - stable
           - 1.88.0
         flags:
-          - "--all-features"
+          - "--no-default-features --features signature-pgp,payload,gzip-compression,zstd-compression,xz-compression,bzip2-compression,zstdmt"
+          - "--no-default-features --features signature-sequoia,payload,gzip-compression,zstd-compression,xz-compression,bzip2-compression,zstdmt"
           - "--no-default-features"
         os:
           - "ubuntu-latest"
@@ -160,4 +161,3 @@ jobs:
 
       - run: cargo install cargo-tarpaulin
       - run: cargo tarpaulin --out xml
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,14 @@ is easy to get wrong from memory.
 ## Building & Testing
 
 ```bash
-cargo test --all-features        # full test suite
-cargo test                       # default features only
-cargo clippy --all-features -- -D warnings
+cargo test                       # default rPGP backend
+cargo test --no-default-features --features signature-sequoia,payload,gzip-compression,zstd-compression,xz-compression,bzip2-compression,zstdmt
+cargo test --no-default-features # minimal build
+cargo clippy -- -D warnings
 cargo fmt --check
 ```
 
-CI tests the full feature matrix: `--all-features`, `--no-default-features`, across Linux/macOS/Windows. Changes must compile under all combinations.
+CI tests the rPGP and Sequoia signature backends separately, plus `--no-default-features`, across Linux/macOS/Windows. The two signature backends are mutually exclusive and must not be enabled together.
 
 ## Feature flags
 
@@ -55,12 +56,12 @@ Fixture RPMs and signing keys live in `tests/assets/`, organized by signature ve
 
 - CHANGELOG.md follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Add entries under `## Unreleased` with appropriate subsection (`Added`, `Fixed`, `Changed`, `Removed`).
 - Commits should explain WHAT and WHY, and reference issues with "Closes #N".
-- Each commit should pass `cargo fmt` and `cargo clippy --all-features -- -D warnings`.
+- Each commit should pass `cargo fmt` and Clippy with each applicable signature backend.
 - The project uses semantic versioning.
 
 ## Common pitfalls
 
-- **Feature combinations**: Code that compiles with `--all-features` may not compile with `--no-default-features`. Always check both.
+- **Feature combinations**: Check the rPGP and Sequoia backends separately, and always check `--no-default-features`.
 - **Binary parsing**: The crate uses `nom` for binary parsing. RPM is a complex binary format with multiple header sections (lead, signature header, main header, payload). Understand the section you're modifying before changing parser code.
 - **Signature versions**: RPM v4 and v6 signatures have different tag sets and structures. v6 adds post-quantum algorithm support. Changes to signature handling must account for both versions.
 - **`#[non_exhaustive]` on errors**: The `Error` enum is non-exhaustive. New error variants can be added without a major version bump, but downstream match arms must have wildcards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- The optional `signature-sequoia` feature provides OpenPGP signing and verification through Sequoia 2.3's pure-Rust crypto backend. Signature backends are mutually exclusive: select Sequoia with `--no-default-features --features signature-sequoia`. The default remains `signature-pgp`, including its draft-PQC support.
+
 ## 0.27.0
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Before marking a PR as ready for review, ensure:
 * Commits are cleanly separated and have useful messages that explain WHAT changed and WHY.
 * A changelog entry has been added to CHANGELOG.md under `## Unreleased`.
 * Code has been appropriately documented (doc comments, etc.)
-* Test coverage is excellent and passes with `--all-features` enabled.
+* Test coverage is excellent and passes with each signature backend enabled separately.
 * Reference related issues with "Closes #N" at the bottom of commit messages.
 
 ## AI-assisted contributions policy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ sha3 = "0.10"
 sha2 = "0.10"
 sha1 = "0.10"
 pgp = { version = "0.20.0", features = ["draft-pqc"], optional = true }
+# Cargo resolves all optional dependencies for one lockfile even when features
+# are mutually exclusive. Sequoia 2.4's stable KEM API therefore cannot coexist
+# in this manifest with rPGP's draft-PQC pre-release KEM API.
+sequoia-openpgp = { version = "=2.3.0", default-features = false, features = ["crypto-rust", "allow-experimental-crypto", "allow-variable-time-crypto"], optional = true }
 getrandom = { version = "0.4.0", optional = true }
 chrono = { version = "0.4", optional = true }
 log = "0.4"
@@ -97,6 +101,7 @@ xz-compression = ["liblzma"]
 bzip2-compression = ["bzip2"]
 
 signature-pgp = ["signature-meta", "pgp", "chrono", "getrandom"]
+signature-sequoia = ["signature-meta", "sequoia-openpgp"]
 signature-meta = []
 
 # Segregate tests that require podman to be installed

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,9 +68,9 @@ pub enum Error {
     #[error("signature packet found, but no version was specified")]
     UnknownVersionSignature,
 
-    #[cfg(feature = "signature-pgp")]
+    #[cfg(any(feature = "signature-pgp", feature = "signature-sequoia"))]
     #[error("error creating signature: {0}")]
-    SignError(#[source] pgp::errors::Error),
+    SignError(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     #[error("error parsing keys, failed to parse bytes as utf8 for ascii armored parsing")]
     KeyLoadUtf8Error(
@@ -79,23 +79,19 @@ pub enum Error {
         Utf8Error,
     ),
 
-    #[cfg(feature = "signature-pgp")]
+    #[cfg(any(feature = "signature-pgp", feature = "signature-sequoia"))]
     #[error("errors parsing keys, failed to parse bytes as ascii armored key")]
-    KeyLoadSecretKeyError(
-        #[from]
-        #[source]
-        pgp::errors::Error,
-    ),
+    KeyLoadSecretKeyError(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     #[cfg(feature = "signature-pgp")]
     #[error("key binding signature verification failed: {0}")]
     KeyBindingVerificationError(pgp::errors::Error),
 
-    #[cfg(feature = "signature-pgp")]
+    #[cfg(any(feature = "signature-pgp", feature = "signature-sequoia"))]
     #[error("error verifying signature with key {key_ref}: {source}")]
     VerificationError {
         #[source]
-        source: pgp::errors::Error,
+        source: Box<dyn std::error::Error + Send + Sync>,
         key_ref: String,
     },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,3 +487,8 @@ pub use crate::rpm::*;
 
 #[cfg(feature = "python")]
 pub mod python;
+#[cfg(all(feature = "signature-pgp", feature = "signature-sequoia"))]
+compile_error!(
+    "the `signature-pgp` and `signature-sequoia` features are mutually exclusive; \
+     disable default features before enabling `signature-sequoia`"
+);

--- a/src/rpm/headers/signatures.rs
+++ b/src/rpm/headers/signatures.rs
@@ -2,19 +2,17 @@
 
 use super::*;
 
-#[cfg(feature = "signature-pgp")]
+#[cfg(feature = "signature-meta")]
 use std::collections::HashSet;
 use std::default::Default;
 
 use crate::RpmFormat;
 use crate::constants::*;
-#[cfg(feature = "signature-pgp")]
-use crate::signature::pgp::Verifier;
+#[cfg(feature = "signature-meta")]
+use crate::signature::{SignatureAlgorithm, parse_signature_info};
 
 use base64::prelude::*;
 use digest::Digest;
-#[cfg(feature = "signature-pgp")]
-use pgp::crypto::public_key::PublicKeyAlgorithm;
 
 /// base signature header builder
 pub struct SignatureHeaderBuilder {
@@ -43,7 +41,7 @@ pub(crate) fn decode_sig(signature: &str) -> Result<Vec<u8>, crate::Error> {
         .map_err(|e| crate::Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))
 }
 
-#[cfg(feature = "signature-pgp")]
+#[cfg(feature = "signature-meta")]
 pub(crate) fn encode_sig(signature: &[u8]) -> String {
     BASE64_STANDARD.encode(signature)
 }
@@ -157,7 +155,7 @@ impl SignatureHeaderBuilder {
     pub fn build(self) -> Result<Header<IndexSignatureTag>, crate::Error> {
         let mut entries = Vec::new();
 
-        #[cfg(feature = "signature-pgp")]
+        #[cfg(feature = "signature-meta")]
         if !self.openpgp_signatures.is_empty() {
             let mut openpgp_signatures = Vec::new();
             let mut legacy_sig = None;
@@ -167,25 +165,24 @@ impl SignatureHeaderBuilder {
             // precedence when deduplicating by issuer fingerprint, and the
             // legacy signature tag is set from the newest matching signature.
             for sig_bytes in self.openpgp_signatures.iter().rev() {
-                let signature = Verifier::parse_signature(sig_bytes)?;
+                let info = parse_signature_info(sig_bytes)?;
 
                 // Deduplicate: keep only the newest signature per key
-                if let Some(fp) = signature.issuer_fingerprint().first()
-                    && !seen_fingerprints.insert(format!("{fp:x}"))
+                if let Some(fp) = info.fingerprint()
+                    && !seen_fingerprints.insert(fp.to_owned())
                 {
                     continue;
                 }
 
                 if legacy_sig.is_none() {
-                    let legacy_sig_tag = match signature
-                        .config()
-                        .ok_or(crate::Error::UnknownVersionSignature)?
-                        .pub_alg
-                    {
-                        PublicKeyAlgorithm::RSA => Some(IndexSignatureTag::RPMSIGTAG_RSA),
-                        PublicKeyAlgorithm::ECDSA
-                        | PublicKeyAlgorithm::EdDSALegacy
-                        | PublicKeyAlgorithm::Ed25519 => Some(IndexSignatureTag::RPMSIGTAG_DSA),
+                    let legacy_sig_tag = match info.algorithm() {
+                        Some(SignatureAlgorithm::RSA) => Some(IndexSignatureTag::RPMSIGTAG_RSA),
+                        Some(
+                            SignatureAlgorithm::ECDSA
+                            | SignatureAlgorithm::EdDSALegacy
+                            | SignatureAlgorithm::Ed25519
+                            | SignatureAlgorithm::Ed448,
+                        ) => Some(IndexSignatureTag::RPMSIGTAG_DSA),
                         _ => None,
                     };
                     if let Some(legacy_sig_tag) = legacy_sig_tag {

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -11,8 +11,6 @@ use num_traits::FromPrimitive;
 
 use crate::{CompressionType, constants::*, errors::*};
 
-#[cfg(feature = "signature-pgp")]
-use crate::signature::pgp::Verifier;
 #[cfg(feature = "signature-meta")]
 use crate::{Timestamp, signature};
 #[cfg(feature = "signature-meta")]
@@ -202,16 +200,16 @@ impl DigestReport {
 }
 
 /// The result of verifying a single signature against the provided keys.
-#[cfg(feature = "signature-pgp")]
+#[cfg(feature = "signature-meta")]
 #[derive(Debug)]
 pub struct SignatureCheckResult {
     /// Parsed metadata about the signature (fingerprint, algorithm, etc.).
-    pub info: signature::pgp::SignatureInfo,
+    pub info: signature::SignatureInfo,
     /// `None` if verified successfully, `Some(error)` if verification failed.
     pub error: Option<Error>,
 }
 
-#[cfg(feature = "signature-pgp")]
+#[cfg(feature = "signature-meta")]
 impl SignatureCheckResult {
     /// Returns `Ok(())` if verified, or `Err` with the verification error.
     pub fn result(&self) -> Result<(), &Error> {
@@ -228,7 +226,7 @@ impl SignatureCheckResult {
 }
 
 /// Results of verifying all digests and signatures in the package.
-#[cfg(feature = "signature-pgp")]
+#[cfg(feature = "signature-meta")]
 #[derive(Debug)]
 pub struct SignatureReport {
     /// Digest verification results.
@@ -237,7 +235,7 @@ pub struct SignatureReport {
     pub signatures: Vec<SignatureCheckResult>,
 }
 
-#[cfg(feature = "signature-pgp")]
+#[cfg(feature = "signature-meta")]
 impl SignatureReport {
     /// Collapse into a `Result`: fails if any digest mismatched or if no signature
     /// was successfully verified.
@@ -453,7 +451,10 @@ impl Package {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut package = rpm::Package::open("tests/assets/RPMS/v4/rpm-basic-2.3.4-5.el9.noarch.rpm")?;
     /// let raw_secret_key = std::fs::read("./tests/assets/signing_keys/v4/rpm-testkey-v4-rsa4096.secret")?;
-    /// let signer = rpm::signature::pgp::Signer::from_asc_bytes(&raw_secret_key)?;
+    /// # #[cfg(feature = "signature-pgp")]
+    /// # let signer = rpm::signature::pgp::Signer::from_asc_bytes(&raw_secret_key)?;
+    /// # #[cfg(feature = "signature-sequoia")]
+    /// # let signer = rpm::signature::sequoia::Signer::from_asc_bytes(&raw_secret_key)?;
     /// // It's recommended to use timestamp of last commit in your VCS
     /// let source_date = 1_600_000_000;
     /// package.sign_with_timestamp(signer, source_date)?;
@@ -629,8 +630,8 @@ impl Package {
     /// Return parsed information about each OpenPGP header signature in the package.
     ///
     /// Delegates to [`PackageMetadata::signatures`].
-    #[cfg(feature = "signature-pgp")]
-    pub fn signatures(&self) -> Result<Vec<signature::pgp::SignatureInfo>, Error> {
+    #[cfg(feature = "signature-meta")]
+    pub fn signatures(&self) -> Result<Vec<signature::SignatureInfo>, Error> {
         self.metadata.signatures()
     }
 
@@ -767,7 +768,10 @@ impl Package {
     ///
     /// ```no_run
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use rpm::signature::pgp::Verifier;
+    /// # #[cfg(feature = "signature-pgp")]
+    /// # use rpm::signature::pgp::Verifier;
+    /// # #[cfg(feature = "signature-sequoia")]
+    /// # use rpm::signature::sequoia::Verifier;
     ///
     /// let pkg = rpm::Package::open("my-package.rpm")?;
     /// let verifier = Verifier::from_asc_bytes(b"-----BEGIN PGP PUBLIC KEY BLOCK-----\n...")?;
@@ -790,7 +794,7 @@ impl Package {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "signature-pgp")]
+    #[cfg(feature = "signature-meta")]
     pub fn check_signatures<V>(&self, verifier: V) -> Result<SignatureReport, Error>
     where
         V: signature::Verifying<Signature = Vec<u8>>,
@@ -1668,26 +1672,17 @@ impl PackageMetadata {
         }
     }
 
-    #[cfg(feature = "signature-pgp")]
-    fn parse_signature_packets(&self) -> Result<Vec<pgp::packet::Signature>, Error> {
-        self.raw_signatures()?
-            .iter()
-            .map(|bytes| Verifier::parse_signature(bytes))
-            .collect()
-    }
-
     /// Return parsed information about each OpenPGP header signature in the package.
     ///
     /// Does not return legacy header + payload signatures (v3 signatures).
     ///
     /// Returns an empty `Vec` if the package is unsigned.
-    #[cfg(feature = "signature-pgp")]
-    pub fn signatures(&self) -> Result<Vec<signature::pgp::SignatureInfo>, Error> {
-        Ok(self
-            .parse_signature_packets()?
+    #[cfg(feature = "signature-meta")]
+    pub fn signatures(&self) -> Result<Vec<signature::SignatureInfo>, Error> {
+        self.raw_signatures()?
             .iter()
-            .map(signature::pgp::SignatureInfo::from_pgp_signature)
-            .collect())
+            .map(|bytes| signature::parse_signature_info(bytes))
+            .collect()
     }
 
     /// Check header digests and return a detailed report.
@@ -1768,7 +1763,7 @@ impl PackageMetadata {
     ///
     /// Payload digest fields are set to [`DigestStatus::NotChecked`].
     /// To check everything, use [`Package::check_signatures`].
-    #[cfg(feature = "signature-pgp")]
+    #[cfg(feature = "signature-meta")]
     pub fn check_signatures<V>(&self, verifier: V) -> Result<SignatureReport, Error>
     where
         V: signature::Verifying<Signature = Vec<u8>>,
@@ -1780,8 +1775,7 @@ impl PackageMetadata {
 
         let mut signatures = Vec::new();
         for sig_bytes in &self.raw_signatures()? {
-            let parsed = Verifier::parse_signature(sig_bytes)?;
-            let info = signature::pgp::SignatureInfo::from_pgp_signature(&parsed);
+            let info = signature::parse_signature_info(sig_bytes)?;
             let error = verifier.verify(header_bytes.as_slice(), sig_bytes).err();
             signatures.push(SignatureCheckResult { info, error });
         }

--- a/src/rpm/signature/meta.rs
+++ b/src/rpm/signature/meta.rs
@@ -1,0 +1,114 @@
+/// The public key algorithm used in an OpenPGP signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SignatureAlgorithm {
+    RSA,
+    DSA,
+    ECDSA,
+    EdDSALegacy,
+    Ed25519,
+    Ed448,
+    MlDsa65Ed25519,
+    MlDsa87Ed448,
+    /// An algorithm not recognized for use signing RPMs.
+    Unsupported(u8),
+}
+
+/// The hash algorithm used in an OpenPGP signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SignatureHashAlgorithm {
+    SHA1,
+    SHA256,
+    SHA384,
+    SHA512,
+    SHA224,
+    SHA3_256,
+    SHA3_512,
+    /// A hash algorithm not recognized by this library.
+    Unsupported(u8),
+}
+
+/// The version of an OpenPGP signature packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SignatureVersion {
+    V4,
+    V6,
+    /// A version not recognized by this library.
+    Unsupported(u8),
+}
+
+impl From<u8> for SignatureVersion {
+    fn from(v: u8) -> Self {
+        match v {
+            4 => Self::V4,
+            6 => Self::V6,
+            other => Self::Unsupported(other),
+        }
+    }
+}
+
+/// Parsed information about a single OpenPGP signature embedded in an RPM package.
+///
+/// This provides access to the issuer fingerprint, key ID, algorithm, and creation time
+/// without exposing the underlying OpenPGP backend's types.
+#[derive(Debug, Clone)]
+pub struct SignatureInfo {
+    fingerprint: Option<String>,
+    key_id: Option<String>,
+    version: SignatureVersion,
+    algorithm: Option<SignatureAlgorithm>,
+    hash_algorithm: Option<SignatureHashAlgorithm>,
+    created: Option<u32>,
+}
+
+impl SignatureInfo {
+    pub(crate) fn new(
+        fingerprint: Option<String>,
+        key_id: Option<String>,
+        version: SignatureVersion,
+        algorithm: Option<SignatureAlgorithm>,
+        hash_algorithm: Option<SignatureHashAlgorithm>,
+        created: Option<u32>,
+    ) -> Self {
+        Self {
+            fingerprint,
+            key_id,
+            version,
+            algorithm,
+            hash_algorithm,
+            created,
+        }
+    }
+
+    /// The issuer fingerprint as a lowercase hex string, if present.
+    pub fn fingerprint(&self) -> Option<&str> {
+        self.fingerprint.as_deref()
+    }
+
+    /// The issuer key ID as a lowercase hex string, if present.
+    pub fn key_id(&self) -> Option<&str> {
+        self.key_id.as_deref()
+    }
+
+    /// The OpenPGP signature packet version (e.g. 4 or 6).
+    pub fn version(&self) -> SignatureVersion {
+        self.version
+    }
+
+    /// The public key algorithm used to create the signature, if known.
+    pub fn algorithm(&self) -> Option<SignatureAlgorithm> {
+        self.algorithm
+    }
+
+    /// The hash algorithm used in the signature, if known.
+    pub fn hash_algorithm(&self) -> Option<SignatureHashAlgorithm> {
+        self.hash_algorithm
+    }
+
+    /// The signature creation time as seconds since the Unix epoch, if present.
+    pub fn created(&self) -> Option<u32> {
+        self.created
+    }
+}

--- a/src/rpm/signature/mod.rs
+++ b/src/rpm/signature/mod.rs
@@ -1,8 +1,26 @@
 mod traits;
 pub use self::traits::*;
 
+#[cfg(feature = "signature-meta")]
+mod meta;
+#[cfg(feature = "signature-meta")]
+pub use self::meta::*;
+
 #[cfg(feature = "signature-pgp")]
 pub mod pgp;
+
+#[cfg(feature = "signature-sequoia")]
+pub mod sequoia;
+
+#[cfg(feature = "signature-pgp")]
+pub(crate) fn parse_signature_info(signature: &[u8]) -> Result<SignatureInfo, crate::Error> {
+    pgp::Verifier::parse_signature(signature).map(|signature| pgp::signature_info(&signature))
+}
+
+#[cfg(all(not(feature = "signature-pgp"), feature = "signature-sequoia"))]
+pub(crate) fn parse_signature_info(signature: &[u8]) -> Result<SignatureInfo, crate::Error> {
+    sequoia::parse_signature_info(signature)
+}
 
 /// test helper to print signatures
 pub fn echo_signature(scope: &str, signature: &[u8]) {

--- a/src/rpm/signature/pgp.rs
+++ b/src/rpm/signature/pgp.rs
@@ -1,4 +1,5 @@
 use super::traits;
+pub use super::{SignatureAlgorithm, SignatureHashAlgorithm, SignatureInfo, SignatureVersion};
 use crate::errors::Error;
 
 use std::{fmt, io};
@@ -13,6 +14,16 @@ use pgp::{
     },
     types::{KeyDetails, KeyVersion, Password, PublicParams, SigningKey},
 };
+
+type BoxedError = Box<dyn std::error::Error + Send + Sync>;
+
+fn key_load_error(error: impl Into<BoxedError>) -> Error {
+    Error::KeyLoadSecretKeyError(error.into())
+}
+
+fn sign_error(error: impl Into<BoxedError>) -> Error {
+    Error::SignError(error.into())
+}
 
 /// An enum that can hold either a primary key or a subkey for signing.
 #[derive(Clone, Debug)]
@@ -117,11 +128,10 @@ impl traits::Signing for Signer {
         let mut sig_cfg = Self::prepare_signer_configuration(&self.signing_key, t)?;
 
         if let Some(ref uid) = self.user_id {
-            sig_cfg
-                .hashed_subpackets
-                .push(Subpacket::regular(SubpacketData::SignersUserID(
-                    uid.clone().into(),
-                ))?);
+            sig_cfg.hashed_subpackets.push(
+                Subpacket::regular(SubpacketData::SignersUserID(uid.clone().into()))
+                    .map_err(sign_error)?,
+            );
         }
 
         let pw = self.key_passphrase.clone().unwrap_or_default();
@@ -129,13 +139,13 @@ impl traits::Signing for Signer {
 
         let signature_packet = sig_cfg
             .sign(&self.signing_key, &Password::Static(passwd), data)
-            .map_err(Error::SignError)?;
+            .map_err(sign_error)?;
 
         let mut signature_bytes = Vec::with_capacity(1024);
         let mut cursor = io::Cursor::new(&mut signature_bytes);
         signature_packet
             .to_writer_with_header(&mut cursor)
-            .map_err(Error::SignError)?;
+            .map_err(sign_error)?;
 
         Ok(signature_bytes)
     }
@@ -178,8 +188,7 @@ impl Signer {
     /// is used for signing by default. Otherwise, the primary key is used.
     /// Use [`Signer::with_signing_key`] to select a specific key by fingerprint.
     pub fn from_asc(input: &str) -> Result<Self, Error> {
-        let (keys_iter, _) =
-            SignedSecretKey::from_string_many(input).map_err(Error::KeyLoadSecretKeyError)?;
+        let (keys_iter, _) = SignedSecretKey::from_string_many(input).map_err(key_load_error)?;
 
         let signed_keys: Vec<SignedSecretKey> = keys_iter
             .filter_map(|res| res.ok())
@@ -215,9 +224,7 @@ impl Signer {
                 None
             })
             .ok_or_else(|| {
-                Error::KeyLoadSecretKeyError(pgp::errors::Error::NoMatchingPacket {
-                    backtrace: None,
-                })
+                key_load_error(pgp::errors::Error::NoMatchingPacket { backtrace: None })
             })?;
 
         Ok(Self {
@@ -301,20 +308,18 @@ impl Signer {
 
         sig_cfg
             .hashed_subpackets
-            .push(Subpacket::regular(SubpacketData::SignatureCreationTime(t))?);
-        sig_cfg
-            .hashed_subpackets
-            .push(Subpacket::regular(SubpacketData::IssuerFingerprint(
-                signing_key.fingerprint(),
-            ))?);
+            .push(Subpacket::regular(SubpacketData::SignatureCreationTime(t)).map_err(sign_error)?);
+        sig_cfg.hashed_subpackets.push(
+            Subpacket::regular(SubpacketData::IssuerFingerprint(signing_key.fingerprint()))
+                .map_err(sign_error)?,
+        );
 
         // v4 signatures include the legacy key ID; v6 signatures do not
         if signing_key.version() != KeyVersion::V6 {
-            sig_cfg
-                .hashed_subpackets
-                .push(Subpacket::regular(SubpacketData::IssuerKeyId(
-                    signing_key.legacy_key_id(),
-                ))?);
+            sig_cfg.hashed_subpackets.push(
+                Subpacket::regular(SubpacketData::IssuerKeyId(signing_key.legacy_key_id()))
+                    .map_err(sign_error)?,
+            );
         }
 
         Ok(sig_cfg)
@@ -391,8 +396,7 @@ impl Verifier {
     /// The input may contain a single certificate or a keyring with multiple
     /// certificates. All certificates with supported algorithms are appended.
     pub fn load_from_asc(&mut self, input: &str) -> Result<(), Error> {
-        let (keys_iter, _) =
-            SignedPublicKey::from_string_many(input).map_err(Error::KeyLoadSecretKeyError)?;
+        let (keys_iter, _) = SignedPublicKey::from_string_many(input).map_err(key_load_error)?;
 
         let mut found_any = false;
         for res in keys_iter {
@@ -407,9 +411,9 @@ impl Verifier {
         }
 
         if !found_any {
-            return Err(Error::KeyLoadSecretKeyError(
-                pgp::errors::Error::NoMatchingPacket { backtrace: None },
-            ));
+            return Err(key_load_error(pgp::errors::Error::NoMatchingPacket {
+                backtrace: None,
+            }));
         }
 
         Ok(())
@@ -536,7 +540,7 @@ impl traits::Verifying for Verifier {
                         Err(source) => {
                             log::trace!("Primary key verification failed");
                             last_err = Some(Error::VerificationError {
-                                source,
+                                source: Box::new(source),
                                 key_ref: format!("{:?}", fingerprint),
                             });
                         }
@@ -560,7 +564,7 @@ impl traits::Verifying for Verifier {
                             Err(source) => {
                                 log::trace!("Subkey verification failed");
                                 last_err = Some(Error::VerificationError {
-                                    source,
+                                    source: Box::new(source),
                                     key_ref: format!("{:?}", sub_key.fingerprint()),
                                 });
                             }
@@ -622,32 +626,16 @@ where
 
         let signature_packet = sig_cfg
             .sign(&self.secret_key, &Password::empty(), data)
-            .map_err(Error::SignError)?;
+            .map_err(sign_error)?;
 
         let mut signature_bytes = Vec::with_capacity(1024);
         let mut cursor = io::Cursor::new(&mut signature_bytes);
         signature_packet
             .to_writer_with_header(&mut cursor)
-            .map_err(Error::SignError)?;
+            .map_err(sign_error)?;
 
         Ok(signature_bytes)
     }
-}
-
-/// The public key algorithm used in an OpenPGP signature.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum SignatureAlgorithm {
-    RSA,
-    DSA,
-    ECDSA,
-    EdDSALegacy,
-    Ed25519,
-    Ed448,
-    MlDsa65Ed25519,
-    MlDsa87Ed448,
-    /// An algorithm not recognized for use signing RPMs.
-    Unsupported(u8),
 }
 
 impl From<PublicKeyAlgorithm> for SignatureAlgorithm {
@@ -666,21 +654,6 @@ impl From<PublicKeyAlgorithm> for SignatureAlgorithm {
     }
 }
 
-/// The hash algorithm used in an OpenPGP signature.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum SignatureHashAlgorithm {
-    SHA1,
-    SHA256,
-    SHA384,
-    SHA512,
-    SHA224,
-    SHA3_256,
-    SHA3_512,
-    /// A hash algorithm not recognized by this library.
-    Unsupported(u8),
-}
-
 impl From<HashAlgorithm> for SignatureHashAlgorithm {
     fn from(alg: HashAlgorithm) -> Self {
         match alg {
@@ -696,93 +669,15 @@ impl From<HashAlgorithm> for SignatureHashAlgorithm {
     }
 }
 
-/// The version of an OpenPGP signature packet.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum SignatureVersion {
-    V4,
-    V6,
-    /// A version not recognized by this library.
-    Unsupported(u8),
-}
-
-impl From<u8> for SignatureVersion {
-    fn from(v: u8) -> Self {
-        match v {
-            4 => Self::V4,
-            6 => Self::V6,
-            other => Self::Unsupported(other),
-        }
-    }
-}
-
-/// Parsed information about a single OpenPGP signature embedded in an RPM package.
-///
-/// This provides access to the issuer fingerprint, key ID, algorithm, and creation time
-/// without exposing the underlying PGP library types.
-#[derive(Debug, Clone)]
-pub struct SignatureInfo {
-    fingerprint: Option<String>,
-    key_id: Option<String>,
-    version: SignatureVersion,
-    algorithm: Option<SignatureAlgorithm>,
-    hash_algorithm: Option<SignatureHashAlgorithm>,
-    created: Option<u32>,
-}
-
-impl SignatureInfo {
-    pub(crate) fn from_pgp_signature(sig: &pgp::packet::Signature) -> Self {
-        let fingerprint = sig.issuer_fingerprint().first().map(|fp| format!("{fp:x}"));
-        let key_id = sig.issuer_key_id().first().map(|kid| format!("{kid}"));
-        let version: SignatureVersion = Into::<u8>::into(sig.version()).into();
-        let algorithm = sig.config().map(|c| c.pub_alg.into());
-        let hash_algorithm = sig.hash_alg().map(|h| h.into());
-        let created = sig.created().map(|t| t.as_secs());
-
-        Self {
-            fingerprint,
-            key_id,
-            version,
-            algorithm,
-            hash_algorithm,
-            created,
-        }
-    }
-
-    /// The issuer fingerprint as a lowercase hex string, if present.
-    ///
-    /// This is always available for v4 and v6 OpenPGP signatures.
-    pub fn fingerprint(&self) -> Option<&str> {
-        self.fingerprint.as_deref()
-    }
-
-    /// The issuer key ID as a lowercase hex string, if present.
-    ///
-    /// This is typically available for v4 OpenPGP signatures but not for v6,
-    /// which only use issuer fingerprint subpackets.
-    pub fn key_id(&self) -> Option<&str> {
-        self.key_id.as_deref()
-    }
-
-    /// The OpenPGP signature packet version (e.g. 4 or 6).
-    pub fn version(&self) -> SignatureVersion {
-        self.version
-    }
-
-    /// The public key algorithm used to create the signature, if known.
-    pub fn algorithm(&self) -> Option<SignatureAlgorithm> {
-        self.algorithm
-    }
-
-    /// The hash algorithm used in the signature, if known.
-    pub fn hash_algorithm(&self) -> Option<SignatureHashAlgorithm> {
-        self.hash_algorithm
-    }
-
-    /// The signature creation time as seconds since the Unix epoch, if present.
-    pub fn created(&self) -> Option<u32> {
-        self.created
-    }
+pub(crate) fn signature_info(sig: &pgp::packet::Signature) -> SignatureInfo {
+    SignatureInfo::new(
+        sig.issuer_fingerprint().first().map(|fp| format!("{fp:x}")),
+        sig.issuer_key_id().first().map(|kid| format!("{kid}")),
+        Into::<u8>::into(sig.version()).into(),
+        sig.config().map(|c| c.pub_alg.into()),
+        sig.hash_alg().map(|h| h.into()),
+        sig.created().map(|t| t.as_secs()),
+    )
 }
 
 #[cfg(test)]

--- a/src/rpm/signature/sequoia.rs
+++ b/src/rpm/signature/sequoia.rs
@@ -1,0 +1,435 @@
+//! OpenPGP signing and verification backed by Sequoia.
+//!
+//! This backend uses Sequoia's pure-Rust crypto implementation. It is selected
+//! instead of, rather than alongside, the `signature-pgp` backend.
+
+use std::fmt;
+use std::io;
+use std::time::{Duration, UNIX_EPOCH};
+
+use openpgp::cert::CertParser;
+use openpgp::packet::signature::SignatureBuilder;
+use openpgp::packet::{Packet, Signature};
+use openpgp::parse::{Parse, stream::*};
+use openpgp::policy::StandardPolicy;
+use openpgp::serialize::stream::{Message, Signer as StreamSigner};
+use openpgp::types::{HashAlgorithm, PublicKeyAlgorithm, SignatureType};
+use openpgp::{Cert, Fingerprint, KeyHandle};
+use sequoia_openpgp as openpgp;
+
+use super::traits;
+pub use super::{SignatureAlgorithm, SignatureHashAlgorithm, SignatureInfo, SignatureVersion};
+use crate::errors::Error;
+
+type BoxedError = Box<dyn std::error::Error + Send + Sync>;
+
+fn key_load_error(error: impl Into<BoxedError>) -> Error {
+    Error::KeyLoadSecretKeyError(error.into())
+}
+
+fn sign_error(error: impl Into<BoxedError>) -> Error {
+    Error::SignError(error.into())
+}
+
+fn verification_error(error: impl Into<BoxedError>, key_ref: impl Into<String>) -> Error {
+    Error::VerificationError {
+        source: error.into(),
+        key_ref: key_ref.into(),
+    }
+}
+
+fn parse_certs(input: &[u8]) -> Result<Vec<Cert>, Error> {
+    let certs = CertParser::from_bytes(input)
+        .map_err(key_load_error)?
+        .collect::<openpgp::Result<Vec<_>>>()
+        .map_err(key_load_error)?;
+
+    if certs.is_empty() {
+        Err(key_load_error(io::Error::other(
+            "no OpenPGP certificates found",
+        )))
+    } else {
+        Ok(certs)
+    }
+}
+
+fn parse_public_certs(input: &[u8]) -> Result<Vec<Cert>, Error> {
+    Ok(parse_certs(input)?
+        .into_iter()
+        .map(Cert::strip_secret_key_material)
+        .collect())
+}
+
+fn find_default_signing_key(certs: &[Cert]) -> Result<Fingerprint, Error> {
+    let policy = StandardPolicy::new();
+    certs
+        .iter()
+        .find_map(|cert| {
+            cert.keys()
+                .secret()
+                .with_policy(&policy, None)
+                .supported()
+                .alive()
+                .revoked(false)
+                .for_signing()
+                .next()
+                .map(|key| key.key().fingerprint())
+        })
+        .ok_or_else(|| key_load_error(io::Error::other("no suitable signing key found")))
+}
+
+/// Signer implementation using Sequoia's pure-Rust crypto backend.
+///
+/// The input may be a single transferable secret key or an armored keyring.
+/// By default, the first policy-valid signing key is selected.
+#[derive(Clone)]
+pub struct Signer {
+    certs: Vec<Cert>,
+    signing_key: Fingerprint,
+    key_passphrase: Option<String>,
+}
+
+impl fmt::Debug for Signer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Signer")
+            .field("certificates", &self.certs.len())
+            .field("signing_key", &self.signing_key)
+            .field("has_key_passphrase", &self.key_passphrase.is_some())
+            .finish()
+    }
+}
+
+impl Signer {
+    /// Construct a signer from an ASCII-armored file.
+    pub fn from_asc_file(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
+        Self::from_asc_bytes(&std::fs::read(path).map_err(Error::Io)?)
+    }
+
+    /// Construct a signer from ASCII-armored bytes.
+    pub fn from_asc_bytes(input: &[u8]) -> Result<Self, Error> {
+        let certs = parse_certs(input)?;
+        let signing_key = find_default_signing_key(&certs)?;
+        Ok(Self {
+            certs,
+            signing_key,
+            key_passphrase: None,
+        })
+    }
+
+    /// Construct a signer from an ASCII-armored string.
+    pub fn from_asc(input: &str) -> Result<Self, Error> {
+        Self::from_asc_bytes(input.as_bytes())
+    }
+
+    /// Select a signing key by its full fingerprint bytes.
+    pub fn with_signing_key(mut self, fingerprint: &[u8]) -> Result<Self, Error> {
+        let policy = StandardPolicy::new();
+        let found = self.certs.iter().find_map(|cert| {
+            cert.keys()
+                .secret()
+                .with_policy(&policy, None)
+                .supported()
+                .alive()
+                .revoked(false)
+                .for_signing()
+                .find(|key| key.key().fingerprint().as_bytes() == fingerprint)
+                .map(|key| key.key().fingerprint())
+        });
+
+        self.signing_key = found.ok_or_else(|| Error::KeyNotFoundError {
+            key_ref: hex::encode(fingerprint),
+        })?;
+        Ok(self)
+    }
+
+    /// Configure the passphrase used to unlock the selected secret key.
+    pub fn with_key_passphrase(mut self, key_passphrase: impl Into<String>) -> Self {
+        self.key_passphrase = Some(key_passphrase.into());
+        self
+    }
+}
+
+impl traits::Signing for Signer {
+    type Signature = Vec<u8>;
+
+    fn sign(&self, mut data: impl io::Read, t: crate::Timestamp) -> Result<Self::Signature, Error> {
+        let policy = StandardPolicy::new();
+        let (cert, signing_key) = self
+            .certs
+            .iter()
+            .find_map(|cert| {
+                cert.keys()
+                    .secret()
+                    .with_policy(&policy, None)
+                    .supported()
+                    .alive()
+                    .revoked(false)
+                    .for_signing()
+                    .find(|key| key.key().fingerprint() == self.signing_key)
+                    .map(|key| (cert, key))
+            })
+            .ok_or_else(|| Error::KeyNotFoundError {
+                key_ref: hex::encode(self.signing_key.as_bytes()),
+            })?;
+
+        let mut key = signing_key.key().clone();
+        if key.secret().is_encrypted() {
+            let passphrase = self
+                .key_passphrase
+                .as_ref()
+                .ok_or_else(|| sign_error(io::Error::other("selected signing key is encrypted")))?;
+            let passphrase: openpgp::crypto::Password = passphrase.clone().into();
+            key.secret_mut()
+                .decrypt_in_place(signing_key.key(), &passphrase)
+                .map_err(sign_error)?;
+        }
+        let keypair = key.into_keypair().map_err(sign_error)?;
+
+        let mut template = SignatureBuilder::new(SignatureType::Binary);
+        if let Ok(userid) = cert
+            .with_policy(&policy, None)
+            .and_then(|cert| cert.primary_userid())
+        {
+            template = template
+                .set_signers_user_id(userid.userid().value())
+                .map_err(sign_error)?;
+        }
+
+        let mut signature = Vec::new();
+        let message = Message::new(&mut signature);
+        let creation_time = UNIX_EPOCH + Duration::from_secs(t.0.into());
+        let mut writer = StreamSigner::with_template(message, keypair, template)
+            .map_err(sign_error)?
+            .detached()
+            .hash_algo(HashAlgorithm::SHA256)
+            .map_err(sign_error)?
+            .creation_time(creation_time)
+            .build()
+            .map_err(sign_error)?;
+        io::copy(&mut data, &mut writer).map_err(Error::Io)?;
+        writer.finalize().map_err(sign_error)?;
+        Ok(signature)
+    }
+}
+
+/// Verifier implementation using Sequoia.
+#[derive(Clone, Default)]
+pub struct Verifier {
+    certs: Vec<Cert>,
+}
+
+impl fmt::Debug for Verifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Verifier")
+            .field("certificates", &self.certs.len())
+            .finish()
+    }
+}
+
+impl Verifier {
+    /// Construct an empty verifier.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a verifier from an ASCII-armored file.
+    pub fn from_asc_file(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
+        Self::from_asc_bytes(&std::fs::read(path).map_err(Error::Io)?)
+    }
+
+    /// Construct a verifier from ASCII-armored bytes.
+    pub fn from_asc_bytes(input: &[u8]) -> Result<Self, Error> {
+        Ok(Self {
+            certs: parse_public_certs(input)?,
+        })
+    }
+
+    /// Construct a verifier from an ASCII-armored string.
+    pub fn from_asc(input: &str) -> Result<Self, Error> {
+        Self::from_asc_bytes(input.as_bytes())
+    }
+
+    /// Append certificates from an ASCII-armored file.
+    pub fn load_from_asc_file(&mut self, path: impl AsRef<std::path::Path>) -> Result<(), Error> {
+        self.load_from_asc_bytes(&std::fs::read(path).map_err(Error::Io)?)
+    }
+
+    /// Append certificates from ASCII-armored bytes.
+    pub fn load_from_asc_bytes(&mut self, input: &[u8]) -> Result<(), Error> {
+        self.certs.extend(parse_public_certs(input)?);
+        Ok(())
+    }
+
+    /// Append certificates from an ASCII-armored string.
+    pub fn load_from_asc(&mut self, input: &str) -> Result<(), Error> {
+        self.load_from_asc_bytes(input.as_bytes())
+    }
+
+    /// Select one certificate by its primary-key fingerprint.
+    pub fn with_key(mut self, fingerprint: &[u8]) -> Result<Self, Error> {
+        self.certs
+            .retain(|cert| cert.fingerprint().as_bytes() == fingerprint);
+        if self.certs.is_empty() {
+            Err(Error::KeyNotFoundError {
+                key_ref: hex::encode(fingerprint),
+            })
+        } else {
+            Ok(self)
+        }
+    }
+}
+
+struct Helper {
+    certs: Vec<Cert>,
+}
+
+impl VerificationHelper for Helper {
+    fn get_certs(&mut self, ids: &[KeyHandle]) -> openpgp::Result<Vec<Cert>> {
+        Ok(self
+            .certs
+            .iter()
+            .filter(|cert| {
+                ids.is_empty()
+                    || cert
+                        .keys()
+                        .any(|key| ids.iter().any(|id| id.aliases(key.key().key_handle())))
+            })
+            .cloned()
+            .collect())
+    }
+
+    fn check(&mut self, structure: MessageStructure) -> openpgp::Result<()> {
+        for layer in structure {
+            if let MessageLayer::SignatureGroup { results } = layer {
+                let mut last_error = None;
+                for result in results {
+                    match result {
+                        Ok(_) => return Ok(()),
+                        Err(error) => last_error = Some(error),
+                    }
+                }
+                if let Some(error) = last_error {
+                    return Err(openpgp::Error::from(error).into());
+                }
+            }
+        }
+        Err(openpgp::Error::BadSignature("no valid detached signature".to_owned()).into())
+    }
+}
+
+impl traits::Verifying for Verifier {
+    type Signature = Vec<u8>;
+
+    fn verify(&self, mut data: impl io::Read, signature: &[u8]) -> Result<(), Error> {
+        let info = parse_signature_info(signature)?;
+        if self.certs.is_empty() {
+            return Err(Error::KeyNotFoundError {
+                key_ref: info
+                    .fingerprint()
+                    .or(info.key_id())
+                    .unwrap_or("no issuer fingerprint in signature")
+                    .to_owned(),
+            });
+        }
+
+        let parsed_signature = parse_signature(signature)?;
+        let has_issuer = parsed_signature.issuer_fingerprints().next().is_some()
+            || parsed_signature.issuers().next().is_some();
+        let has_matching_key = self.certs.iter().any(|cert| {
+            cert.keys().any(|key| {
+                parsed_signature
+                    .issuer_fingerprints()
+                    .any(|fingerprint| fingerprint == &key.key().fingerprint())
+                    || parsed_signature
+                        .issuers()
+                        .any(|key_id| key_id == &key.key().keyid())
+            })
+        });
+        if has_issuer && !has_matching_key {
+            return Err(Error::KeyNotFoundError {
+                key_ref: info
+                    .fingerprint()
+                    .or(info.key_id())
+                    .unwrap_or("unknown OpenPGP key")
+                    .to_owned(),
+            });
+        }
+
+        let policy = StandardPolicy::new();
+        let helper = Helper {
+            certs: self.certs.clone(),
+        };
+        let key_ref = info
+            .fingerprint()
+            .or(info.key_id())
+            .unwrap_or("unknown OpenPGP key")
+            .to_owned();
+        let mut verifier = DetachedVerifierBuilder::from_bytes(signature)
+            .map_err(|error| verification_error(error, &key_ref))?
+            .with_policy(&policy, None, helper)
+            .map_err(|error| verification_error(error, &key_ref))?;
+        let mut data_bytes = Vec::new();
+        data.read_to_end(&mut data_bytes).map_err(Error::Io)?;
+        verifier
+            .verify_bytes(&data_bytes)
+            .map_err(|error| verification_error(error, key_ref))
+    }
+}
+
+fn signature_algorithm(algorithm: PublicKeyAlgorithm) -> SignatureAlgorithm {
+    #[allow(deprecated)]
+    match algorithm {
+        PublicKeyAlgorithm::RSAEncryptSign | PublicKeyAlgorithm::RSASign => SignatureAlgorithm::RSA,
+        PublicKeyAlgorithm::DSA => SignatureAlgorithm::DSA,
+        PublicKeyAlgorithm::ECDSA => SignatureAlgorithm::ECDSA,
+        PublicKeyAlgorithm::EdDSA => SignatureAlgorithm::EdDSALegacy,
+        PublicKeyAlgorithm::Ed25519 => SignatureAlgorithm::Ed25519,
+        PublicKeyAlgorithm::Ed448 => SignatureAlgorithm::Ed448,
+        other => SignatureAlgorithm::Unsupported(other.into()),
+    }
+}
+
+fn signature_hash_algorithm(algorithm: HashAlgorithm) -> SignatureHashAlgorithm {
+    match algorithm {
+        HashAlgorithm::SHA1 => SignatureHashAlgorithm::SHA1,
+        HashAlgorithm::SHA256 => SignatureHashAlgorithm::SHA256,
+        HashAlgorithm::SHA384 => SignatureHashAlgorithm::SHA384,
+        HashAlgorithm::SHA512 => SignatureHashAlgorithm::SHA512,
+        HashAlgorithm::SHA224 => SignatureHashAlgorithm::SHA224,
+        HashAlgorithm::SHA3_256 => SignatureHashAlgorithm::SHA3_256,
+        HashAlgorithm::SHA3_512 => SignatureHashAlgorithm::SHA3_512,
+        other => SignatureHashAlgorithm::Unsupported(other.into()),
+    }
+}
+
+fn parse_signature(signature: &[u8]) -> Result<Signature, Error> {
+    match Packet::from_bytes(signature)
+        .map_err(|error| verification_error(error, "unknown OpenPGP key"))?
+    {
+        Packet::Signature(signature) => Ok(signature),
+        _ => Err(Error::NoSignatureFound),
+    }
+}
+
+pub(crate) fn parse_signature_info(signature: &[u8]) -> Result<SignatureInfo, Error> {
+    let signature = parse_signature(signature)?;
+    let created = signature
+        .signature_creation_time()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .and_then(|duration| u32::try_from(duration.as_secs()).ok());
+
+    Ok(SignatureInfo::new(
+        signature
+            .issuer_fingerprints()
+            .next()
+            .map(|fingerprint| hex::encode(fingerprint.as_bytes())),
+        signature
+            .issuers()
+            .next()
+            .map(|key_id| hex::encode(key_id.as_bytes())),
+        signature.version().into(),
+        Some(signature_algorithm(signature.pk_algo())),
+        Some(signature_hash_algorithm(signature.hash_algo())),
+        created,
+    ))
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -44,7 +44,10 @@ fn test_package_segment_boundaries() -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(all(feature = "payload", feature = "signature-meta"))]
     {
+        #[cfg(feature = "signature-pgp")]
         use rpm::signature::pgp::Signer;
+        #[cfg(feature = "signature-sequoia")]
+        use rpm::signature::sequoia::Signer;
         let signer = Signer::from_asc_file(common::keys::v4::RSA_4K_PRIVATE)?;
         let constructed_pkg_with_sig =
             rpm::PackageBuilder::new("empty-package", "0", "MIT", "x86_64", "")

--- a/tests/signatures.rs
+++ b/tests/signatures.rs
@@ -2,12 +2,18 @@ use std::fs;
 use std::path::Path;
 
 use hex;
-use rpm::{
-    self,
-    signature::pgp::{Signer, Verifier},
-};
+use rpm::{self};
+
+#[cfg(feature = "signature-pgp")]
+use rpm::signature::pgp::{Signer, Verifier};
+#[cfg(feature = "signature-sequoia")]
+use rpm::signature::sequoia::{Signer, Verifier};
 
 mod common;
+
+fn test_timestamp() -> rpm::Timestamp {
+    rpm::Timestamp(1_780_000_000)
+}
 
 /// Resign an already-signed package with new keys, and verify it with the new keys
 #[test]
@@ -70,14 +76,16 @@ fn test_rpm_file_signatures_resign() -> Result<(), Box<dyn std::error::Error>> {
         "v6_eddsa_resigned_pkg.rpm",
     )?;
 
-    // test v6 ML-DSA
+    #[cfg(feature = "signature-pgp")]
     resign_and_verify_with_keys(
         pkg_path.as_ref(),
         &fs::read(common::keys::v6::MLDSA65_ED25519_PRIVATE)?,
         None,
         &fs::read(common::keys::v6::MLDSA65_ED25519_PUBLIC)?,
         "v6_mldsa_resigned_pkg.rpm",
-    )
+    )?;
+
+    Ok(())
 }
 
 /// Test parsing packages that were built and signed by RPM
@@ -115,7 +123,7 @@ fn parse_externally_signed_rpm_and_verify() -> Result<(), Box<dyn std::error::Er
         common::keys::v6::ED25519_PUBLIC,
     )?;
 
-    // v6 ML-DSA
+    #[cfg(feature = "signature-pgp")]
     open_and_verify(
         common::pkgs::v6::RPM_BASIC_MLDSA_SIGNED,
         common::keys::v6::MLDSA65_ED25519_PUBLIC,
@@ -320,6 +328,7 @@ fn test_cross_version_resign() -> Result<(), Box<dyn std::error::Error>> {
         "cross_v4_with_v6_eddsa_resigned_pkg.rpm",
     )?;
 
+    #[cfg(feature = "signature-pgp")]
     resign_and_verify_with_keys(
         v4_pkg_path.as_ref(),
         &fs::read(common::keys::v6::MLDSA65_ED25519_PRIVATE)?,
@@ -389,7 +398,7 @@ fn resign_and_verify_with_keys(
     if let Some(passphrase) = signing_key_passphrase {
         signer = signer.with_key_passphrase(passphrase);
     }
-    package.sign_with_timestamp(&signer, 1_600_000_000)?;
+    package.sign_with_timestamp(&signer, test_timestamp())?;
 
     let out_file = Path::new(common::CARGO_OUT_DIR).join(pkg_out_path.as_ref());
     package.write_file(&out_file)?;
@@ -430,13 +439,17 @@ mod keyring {
         let keyring_verifier = Verifier::from_asc_file(common::keys::v4::KEYRING_PUBLIC)?;
         pkg.verify_signature(&keyring_verifier)?;
 
-        // v6
-        let keyring_signer = Signer::from_asc_bytes(&fs::read(common::keys::v6::KEYRING_PRIVATE)?)?;
-        let pkg = rpm::PackageBuilder::new("foo", "1.0.0", "MIT", "x86_64", "keyring signer test")
-            .build_and_sign(&keyring_signer)?;
+        #[cfg(feature = "signature-pgp")]
+        {
+            let keyring_signer =
+                Signer::from_asc_bytes(&fs::read(common::keys::v6::KEYRING_PRIVATE)?)?;
+            let pkg =
+                rpm::PackageBuilder::new("foo", "1.0.0", "MIT", "x86_64", "keyring signer test")
+                    .build_and_sign(&keyring_signer)?;
 
-        let keyring_verifier = Verifier::from_asc_file(common::keys::v6::KEYRING_PUBLIC)?;
-        pkg.verify_signature(&keyring_verifier)?;
+            let keyring_verifier = Verifier::from_asc_file(common::keys::v6::KEYRING_PUBLIC)?;
+            pkg.verify_signature(&keyring_verifier)?;
+        }
 
         Ok(())
     }
@@ -701,7 +714,7 @@ fn test_verify_digests_standalone() -> Result<(), Box<dyn std::error::Error>> {
 /// Test the signatures() API returns correct info for signed and unsigned packages
 #[test]
 fn test_signatures() -> Result<(), Box<dyn std::error::Error>> {
-    use rpm::signature::pgp::{SignatureAlgorithm, SignatureHashAlgorithm, SignatureVersion};
+    use rpm::signature::{SignatureAlgorithm, SignatureHashAlgorithm, SignatureVersion};
 
     // Unsigned packages should return an empty Vec
     assert!(
@@ -754,13 +767,19 @@ fn test_signatures() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(sigs.len(), 1);
     assert_eq!(sigs[0].algorithm(), Some(SignatureAlgorithm::Ed25519));
 
-    // v6 ML-DSA
+    // Sequoia 2.3 can parse the packet but does not classify the draft-PQC algorithm.
     let pkg = rpm::Package::open(common::pkgs::v6::RPM_BASIC_MLDSA_SIGNED)?;
     let sigs = pkg.signatures()?;
     assert_eq!(sigs.len(), 1);
+    #[cfg(feature = "signature-pgp")]
     assert_eq!(
         sigs[0].algorithm(),
         Some(SignatureAlgorithm::MlDsa65Ed25519)
+    );
+    #[cfg(feature = "signature-sequoia")]
+    assert_eq!(
+        sigs[0].algorithm(),
+        Some(SignatureAlgorithm::Unsupported(30))
     );
 
     // v6 multi-signed
@@ -1015,6 +1034,7 @@ fn test_clear_package_signatures() -> Result<(), Box<dyn std::error::Error>> {
         &fs::read(common::keys::v6::ED25519_PRIVATE)?,
         &fs::read(common::keys::v6::ED25519_PUBLIC)?,
     )?;
+    #[cfg(feature = "signature-pgp")]
     sign_clear_and_verify(
         &fs::read(common::keys::v6::MLDSA65_ED25519_PRIVATE)?,
         &fs::read(common::keys::v6::MLDSA65_ED25519_PUBLIC)?,
@@ -1441,6 +1461,7 @@ mod signature_roundtrip {
             common::keys::v6::ED25519_PUBLIC,
             "roundtrip_v6_eddsa.rpm",
         )?;
+        #[cfg(feature = "signature-pgp")]
         roundtrip(
             common::keys::v6::MLDSA65_ED25519_PRIVATE,
             common::keys::v6::MLDSA65_ED25519_PUBLIC,
@@ -1894,11 +1915,8 @@ mod in_place_signing {
         let ed_signer = Signer::from_asc_file(common::keys::v4::ED25519_PRIVATE)?;
         let metadata = rpm::PackageMetadata::open(&out)?;
         let header_bytes = metadata.header_bytes()?;
-        let ed_sig = rpm::signature::Signing::sign(
-            &ed_signer,
-            header_bytes.as_slice(),
-            rpm::Timestamp(1_600_000_000),
-        )?;
+        let ed_sig =
+            rpm::signature::Signing::sign(&ed_signer, header_bytes.as_slice(), test_timestamp())?;
 
         // First in-place apply
         rpm::Package::apply_signature_in_place(&out, ed_sig)?;
@@ -1915,7 +1933,7 @@ mod in_place_signing {
         let ecdsa_sig = rpm::signature::Signing::sign(
             &ecdsa_signer,
             header_bytes.as_slice(),
-            rpm::Timestamp(1_600_000_000),
+            test_timestamp(),
         )?;
 
         // Second in-place apply


### PR DESCRIPTION
### Summary

- add an optional `signature-sequoia` backend using Sequoia 2.3 and its pure-Rust crypto implementation
- keep `signature-pgp` as the default while making the two signature backends mutually exclusive
- move signature metadata into backend-neutral types so either backend can inspect RPM signatures
- support armored keyrings, explicit key selection, protected keys, RPM v4/v6 signing and verification, and RSA, Ed25519, and ECDSA fixtures
- run the existing shared signature test suite against either backend and test both configurations independently in CI
- preserve the default rPGP draft-PQC support; Sequoia remains pinned to 2.3 because Cargo resolves optional dependencies into one lockfile, so Sequoia 2.4's stable `kem` API cannot coexist in this manifest with rPGP's draft-PQC pre-release `kem` API even when the features are mutually exclusive

### Validation

- `cargo test`
- `cargo test --no-default-features`
- `cargo test --no-default-features --features signature-pgp,payload,gzip-compression,zstd-compression,xz-compression,bzip2-compression,zstdmt`
- `cargo test --no-default-features --features signature-sequoia,payload,gzip-compression,zstd-compression,xz-compression,bzip2-compression,zstdmt`
- Clippy with default, minimal, and Sequoia configurations using `-D warnings`
- Rust 1.88 checks for both backend configurations
- `cargo fmt --all -- --check`

### Checklist

- [x] Commits are cleanly separated and have useful messages
- [x] A changelog entry has been added
- [x] Documentation covers backend selection and the dependency constraint
- [x] Both backends use the shared signature suite
- [x] CI tests the mutually exclusive backend configurations in parallel

Closes #334

AI-assisted: Codex was used for implementation assistance. I reviewed and validated the change, and the commits include the required `Assisted-by` trailer.
