### PR TITLE
Fix files()/extract() failing after decompress_payload()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.27.1
+
 ### Added
 
 - `CompressionType::detect()` identifies compression from magic bytes (gzip, zstd, xz, bzip2, CPIO).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `CompressionType::detect()` identifies compression from magic bytes (gzip, zstd, xz, bzip2, CPIO).
+- `Package::payload_compression()` returns the effective compression by inspecting the payload bytes rather than relying on the `PAYLOADCOMPRESSOR` header tag.
+
+### Fixed
+
+- `Package::files()` and `Package::extract()` now work correctly after `Package::decompress_payload()` has been called. Previously they read the `PAYLOADCOMPRESSOR` header tag, which still declared the original compression, and attempted to decompress already-decompressed data.
+
 ## 0.27.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpm"
-version = "0.27.0"
+version = "0.27.1"
 authors = [
   "René Richter <richterrettich@gmail.com>",
   "Bernhard Schuster <bernhard@ahoi.io>",

--- a/src/python.rs
+++ b/src/python.rs
@@ -754,7 +754,15 @@ impl PyPackageMetadata {
         self.0.get_installed_size().map_err(to_pyerr)
     }
 
-    /// Name of the compression algorithm used for the payload (e.g. "Zstd", "Gzip").
+    /// Name of the compression algorithm declared in the ``PAYLOADCOMPRESSOR``
+    /// header tag (e.g. ``"Zstd"``, ``"Gzip"``).
+    ///
+    /// .. note::
+    ///
+    ///    This reflects the *original* compression recorded at build time.
+    ///    After :meth:`Package.decompress_payload` the tag is intentionally
+    ///    left unchanged, so it may no longer match the actual payload bytes.
+    ///    Use :attr:`Package.payload_compression` for the effective compression.
     #[getter]
     fn payload_compressor(&self) -> PyResult<String> {
         self.0

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -236,20 +236,10 @@ mod encoding {
     }
 
     pub(crate) fn decompress_stream<'a>(
-        value: CompressionType,
         mut reader: impl io::BufRead + 'a,
     ) -> Result<Box<dyn io::Read + 'a>, Error> {
-        // Detect the actual compression from magic bytes, overriding the declared type
-        // when they disagree (e.g. after an in-place decompression).
-        let buf = reader.fill_buf().unwrap_or(&[]);
-        let detected = CompressionType::detect(buf);
-        let is_cpio = is_cpio_magic(buf);
-        let effective = match detected {
-            c if c != CompressionType::None => c,
-            CompressionType::None if is_cpio => CompressionType::None,
-            _ => value,
-        };
-        match effective {
+        let compression = CompressionType::detect(reader.fill_buf().unwrap_or(&[]));
+        match compression {
             CompressionType::None => Ok(Box::new(reader)),
             #[cfg(feature = "gzip-compression")]
             CompressionType::Gzip => Ok(Box::new(flate2::bufread::GzDecoder::new(reader))),
@@ -259,9 +249,8 @@ mod encoding {
             CompressionType::Xz => Ok(Box::new(liblzma::bufread::XzDecoder::new(reader))),
             #[cfg(feature = "bzip2-compression")]
             CompressionType::Bzip2 => Ok(Box::new(bzip2::bufread::BzDecoder::new(reader))),
-            // This is an issue when building with all compression types enabled
             #[allow(unreachable_patterns)]
-            _ => Err(Error::UnsupportedCompressorType(value.to_string())),
+            _ => Err(Error::UnsupportedCompressorType(compression.to_string())),
         }
     }
 }

--- a/src/rpm/compressor.rs
+++ b/src/rpm/compressor.rs
@@ -22,6 +22,30 @@ impl std::fmt::Display for CompressionType {
     }
 }
 
+impl CompressionType {
+    /// Detect the compression type from magic bytes at the start of a buffer.
+    ///
+    /// Returns `None` (the variant, not `Option::None`) when the data starts
+    /// with a CPIO magic (`070701`, `070702`, `07070X`) or no known
+    /// compression magic is found.
+    pub fn detect(data: &[u8]) -> Self {
+        if is_cpio_magic(data) {
+            CompressionType::None
+        } else if data.starts_with(&[0x1f, 0x8b]) {
+            CompressionType::Gzip
+        } else if data.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]) {
+            CompressionType::Zstd
+        } else if data.starts_with(&[0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00]) {
+            CompressionType::Xz
+        } else if data.starts_with(&[0x42, 0x5a]) {
+            // b"BZ"
+            CompressionType::Bzip2
+        } else {
+            CompressionType::None
+        }
+    }
+}
+
 impl std::str::FromStr for CompressionType {
     type Err = Error;
     fn from_str(raw: &str) -> Result<Self, Self::Err> {
@@ -33,6 +57,10 @@ impl std::str::FromStr for CompressionType {
             _ => Err(Error::UnknownCompressorType(raw.to_string())),
         }
     }
+}
+
+fn is_cpio_magic(data: &[u8]) -> bool {
+    data.starts_with(b"070701") || data.starts_with(b"070702") || data.starts_with(b"07070X")
 }
 
 #[cfg(feature = "payload")]
@@ -209,9 +237,19 @@ mod encoding {
 
     pub(crate) fn decompress_stream<'a>(
         value: CompressionType,
-        reader: impl io::BufRead + 'a,
+        mut reader: impl io::BufRead + 'a,
     ) -> Result<Box<dyn io::Read + 'a>, Error> {
-        match value {
+        // Detect the actual compression from magic bytes, overriding the declared type
+        // when they disagree (e.g. after an in-place decompression).
+        let buf = reader.fill_buf().unwrap_or(&[]);
+        let detected = CompressionType::detect(buf);
+        let is_cpio = is_cpio_magic(buf);
+        let effective = match detected {
+            c if c != CompressionType::None => c,
+            CompressionType::None if is_cpio => CompressionType::None,
+            _ => value,
+        };
+        match effective {
             CompressionType::None => Ok(Box::new(reader)),
             #[cfg(feature = "gzip-compression")]
             CompressionType::Gzip => Ok(Box::new(flate2::bufread::GzDecoder::new(reader))),

--- a/src/rpm/content.rs
+++ b/src/rpm/content.rs
@@ -60,10 +60,7 @@ impl Package {
     /// ```
     pub fn files(&self) -> Result<FileIterator<'_>, Error> {
         let file_entries = self.metadata.get_file_entries()?;
-        let archive = decompress_stream(
-            self.metadata.get_payload_compressor()?,
-            io::Cursor::new(&self.payload),
-        )?;
+        let archive = decompress_stream(io::Cursor::new(&self.payload))?;
 
         Ok(FileIterator {
             file_entries,
@@ -111,10 +108,7 @@ impl Package {
             fs::create_dir_all(&dir_path)?;
         }
 
-        let mut archive = decompress_stream(
-            self.metadata.get_payload_compressor()?,
-            io::Cursor::new(&self.payload),
-        )?;
+        let mut archive = decompress_stream(io::Cursor::new(&self.payload))?;
         let file_entries = self.metadata.get_file_entries()?;
 
         for file_entry in file_entries.iter() {
@@ -305,13 +299,12 @@ impl PackageReader {
     /// on demand as you call [`next_file`](Self::next_file).
     pub fn parse(mut input: impl io::BufRead + 'static) -> Result<Self, Error> {
         let metadata = PackageMetadata::parse(&mut input)?;
-        let compression = metadata.get_payload_compressor()?;
         let file_entries = metadata
             .get_file_entries()?
             .into_iter()
             .map(|e| e.into_owned())
             .collect();
-        let archive = decompress_stream(compression, input)?;
+        let archive = decompress_stream(input)?;
         Ok(PackageReader {
             metadata,
             file_entries,

--- a/src/rpm/content.rs
+++ b/src/rpm/content.rs
@@ -540,6 +540,45 @@ mod test_payload_integration {
         test_basic_package_files(&package)
     }
 
+    #[test]
+    #[cfg(feature = "gzip-compression")]
+    fn test_files_after_decompress_gzip() -> Result<(), Box<dyn std::error::Error>> {
+        let mut package = Package::open(pkgs::v6::compressed::RPM_BASIC_GZIP)?;
+        assert_eq!(package.payload_compression()?, CompressionType::Gzip);
+        package.decompress_payload()?;
+        assert_eq!(package.payload_compression()?, CompressionType::None);
+        test_basic_package_files(&package)
+    }
+
+    #[test]
+    #[cfg(feature = "zstd-compression")]
+    fn test_files_after_decompress_zstd() -> Result<(), Box<dyn std::error::Error>> {
+        let mut package = Package::open(pkgs::v6::compressed::RPM_BASIC_ZSTD)?;
+        assert_eq!(package.payload_compression()?, CompressionType::Zstd);
+        package.decompress_payload()?;
+        assert_eq!(package.payload_compression()?, CompressionType::None);
+        test_basic_package_files(&package)
+    }
+
+    #[test]
+    #[cfg(feature = "xz-compression")]
+    fn test_files_after_decompress_xz() -> Result<(), Box<dyn std::error::Error>> {
+        let mut package = Package::open(pkgs::v6::compressed::RPM_BASIC_XZ)?;
+        assert_eq!(package.payload_compression()?, CompressionType::Xz);
+        package.decompress_payload()?;
+        assert_eq!(package.payload_compression()?, CompressionType::None);
+        test_basic_package_files(&package)
+    }
+
+    #[test]
+    fn test_files_after_decompress_noop() -> Result<(), Box<dyn std::error::Error>> {
+        let mut package = Package::open(pkgs::v6::RPM_BASIC)?;
+        assert_eq!(package.payload_compression()?, CompressionType::None);
+        package.decompress_payload()?;
+        assert_eq!(package.payload_compression()?, CompressionType::None);
+        test_basic_package_files(&package)
+    }
+
     /// Shared test logic for verifying file extraction across all compression types.
     #[track_caller]
     fn test_basic_package_files(package: &Package) -> Result<(), Box<dyn std::error::Error>> {
@@ -1800,6 +1839,37 @@ mod test_payload_integration {
         }
 
         assert_eq!(ghost_seen, ghost_count);
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "zstd-compression")]
+    fn test_package_reader_after_decompress_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+        let mut package = Package::open(pkgs::v6::compressed::RPM_BASIC_ZSTD)?;
+        let expected: Vec<_> = package
+            .files()?
+            .map(|r| r.map(|f| (f.metadata.path().to_owned(), f.content)))
+            .collect::<Result<_, _>>()?;
+
+        package.decompress_payload()?;
+
+        let mut buf = Vec::new();
+        package.write(&mut buf)?;
+
+        let mut reader = PackageReader::parse(std::io::BufReader::new(std::io::Cursor::new(buf)))?;
+        let mut actual = Vec::new();
+        while let Some(mut file) = reader.next_file()? {
+            let mut content = Vec::new();
+            file.read_to_end(&mut content)?;
+            actual.push((file.metadata.path().to_owned(), content));
+            file.finish()?;
+        }
+
+        assert_eq!(actual.len(), expected.len());
+        for (i, (path, content)) in actual.iter().enumerate() {
+            assert_eq!(*path, expected[i].0);
+            assert_eq!(*content, expected[i].1);
+        }
         Ok(())
     }
 }

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -365,6 +365,14 @@ impl Package {
         self.metadata.header_bytes()
     }
 
+    /// Return the effective payload compression type by inspecting the payload magic bytes.
+    ///
+    /// This detects the actual compression so that methods like [`files`](Self::files)
+    /// work correctly even after [`decompress_payload`](Self::decompress_payload) has been called.
+    pub fn payload_compression(&self) -> Result<CompressionType, Error> {
+        Ok(CompressionType::detect(&self.payload))
+    }
+
     /// Decompress the payload in-place, replacing the compressed bytes with
     /// the raw (uncompressed) archive.
     ///
@@ -381,13 +389,16 @@ impl Package {
     /// This is a no-op if the payload compressor is already [`CompressionType::None`].
     #[cfg(feature = "payload")]
     pub fn decompress_payload(&mut self) -> Result<(), Error> {
-        let compressor = self.metadata.get_payload_compressor()?;
-        if compressor == CompressionType::None {
+        let declared_compression = self.metadata.get_payload_compressor()?;
+        if declared_compression == CompressionType::None {
             return Ok(());
         }
         let mut decompressed = Vec::new();
-        crate::decompress_stream(compressor, io::Cursor::new(self.payload.as_slice()))?
-            .read_to_end(&mut decompressed)?;
+        crate::decompress_stream(
+            declared_compression,
+            io::Cursor::new(self.payload.as_slice()),
+        )?
+        .read_to_end(&mut decompressed)?;
         self.payload = decompressed;
 
         let header_bytes = self.header_bytes()?;
@@ -1353,6 +1364,12 @@ impl PackageMetadata {
             })
     }
 
+    /// Return the payload compressor declared in the `PAYLOADCOMPRESSOR` header tag.
+    ///
+    /// **Caveat:** This reflects the *original* compression recorded at build time.
+    /// After [`Package::decompress_payload`] the tag is intentionally left unchanged,
+    /// so it may no longer match the actual payload bytes. Use [`Package::payload_compression`]
+    /// when you need the effective compression of the in-memory payload.
     #[inline]
     pub fn get_payload_compressor(&self) -> Result<CompressionType, Error> {
         self.header

--- a/src/rpm/package.rs
+++ b/src/rpm/package.rs
@@ -389,16 +389,12 @@ impl Package {
     /// This is a no-op if the payload compressor is already [`CompressionType::None`].
     #[cfg(feature = "payload")]
     pub fn decompress_payload(&mut self) -> Result<(), Error> {
-        let declared_compression = self.metadata.get_payload_compressor()?;
-        if declared_compression == CompressionType::None {
+        if self.payload_compression()? == CompressionType::None {
             return Ok(());
         }
         let mut decompressed = Vec::new();
-        crate::decompress_stream(
-            declared_compression,
-            io::Cursor::new(self.payload.as_slice()),
-        )?
-        .read_to_end(&mut decompressed)?;
+        crate::decompress_stream(io::Cursor::new(self.payload.as_slice()))?
+            .read_to_end(&mut decompressed)?;
         self.payload = decompressed;
 
         let header_bytes = self.header_bytes()?;


### PR DESCRIPTION
After decompress_payload(), the PAYLOADCOMPRESSOR header tag still declared the original compression, so files() and extract() would attempt to decompress already-decompressed data.

Add CompressionType::detect() to identify compression from magic bytes (gzip, zstd, xz, bzip2) and CPIO archive headers (070701, 070702, 07070X). Add Package::payload_compression() which uses byte-level detection instead of the header tag, and wire it into files(), extract(), and decompress_payload() itself.

Assisted-By: Claude Opus 4.6

<!---
Thank you for submitting a PR to the rust rpm implementation!

Commits should be distinct and have a clear purpose, with messages
which explain to the reviewer WHAT changed, and WHY it had to change
and how the WHAT and the WHY tie together.

At the bottom of your commit messages, add a line "Closes #IssueNumber)"
for any issues resolved by the commit, substituting in an actual issue number.
This will automatically close the issue once the PR is merged and creates a
cross reference.

If things are still WIP or feedback on particular impl details
are wanted, state them here or leave comments below.
-->

### 📜 Checklist

- [ ] Commits are cleanly separated and have useful messages
- [ ] A changelog entry or entries has been added to CHANGELOG.md
- [ ] Documentation is thorough
- [ ] Test coverage is excellent and passes
- [ ] Works when tests are run `--all-features` enabled
